### PR TITLE
test: Add red team test suite (3500+ adversarial cases)

### DIFF
--- a/tests/red_team/conftest.py
+++ b/tests/red_team/conftest.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+"""
+Red Team Test Suite — Shared Configuration and Fixtures
+
+Related GitHub Issue:
+    #43 - Red team test suite: adversarial, unicode, and boundary inputs across all pattern types
+    https://github.com/craigtrim/fast-parse-time/issues/43
+
+PURPOSE OF THIS SUITE
+─────────────────────
+Standard regression tests verify that known-good inputs produce known-good outputs.
+Red team testing is the adversarial complement: it asks, "what happens when we feed
+the parser inputs it was never designed for — or inputs that *look* designed for it
+but are subtly wrong?"
+
+This suite is organized into three attack categories:
+
+  1. TRUE POSITIVE ATTACKS
+     Inputs that *should* parse successfully. The goal is to find inputs that a
+     human would recognize as temporal but the parser silently drops. These reveal
+     coverage gaps — patterns the parser doesn't yet handle.
+
+  2. FALSE POSITIVE ATTACKS (false positive DEFENSE)
+     Inputs that *should not* parse. The goal is to find inputs that superficially
+     resemble temporal expressions but are not (IP addresses, version strings,
+     non-temporal uses of month names, etc.). These reveal over-matching — places
+     where the parser hallucinates dates.
+
+  3. BOUNDARY AND EDGE CASES
+     Inputs at or just beyond the valid range: minimum/maximum year, day 0, day 32,
+     leap-day validation, zero cardinality, very large cardinality, negative numbers,
+     and floating-point values. These reveal where the parser's guards begin and end.
+
+  4. UNICODE AND HOMOGLYPH ATTACKS
+     Inputs that use visually similar Unicode characters in place of ASCII: full-width
+     digits, Arabic-Indic digits, homoglyph punctuation (en-dash, em-dash, fullwidth
+     slash), and invisible control characters (zero-width space, RTL override, soft
+     hyphen). These reveal whether the parser is brittle to Unicode normalization.
+
+PHASE 1 VS PHASE 2
+──────────────────
+All tests in this suite start as `xfail` (marked at the module level in each file
+with `pytestmark`). This means:
+
+  - A test that FAILS   → reported as `xfail`  (expected failure, suite stays green)
+  - A test that PASSES  → reported as `xpass`  (unexpected pass — candidate for promotion)
+
+In Phase 2, `xpass` tests and clear-behavior tests are promoted to hard assertions.
+See issue #43 for the full promotion decision matrix.
+
+ACADEMIC INTENT
+───────────────
+Each test function in this suite carries a rich docstring that explains:
+  - The specific attack vector being probed
+  - Why a real parser might be fooled by this input
+  - What a failure (or unexpected pass) reveals about the implementation
+  - How to interpret the result in the context of the parser's architecture
+
+This makes the suite useful not just as a quality gate but as educational material
+for understanding the edge cases of temporal NLP parsing.
+"""

--- a/tests/red_team/test_rt_compound_multi_unit.py
+++ b/tests/red_team/test_rt_compound_multi_unit.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+"""
+Red Team: Compound Multi-Unit Expressions
+(1 year 2 months ago, in 1 year 2 months, 1 year and 2 months ago)
+Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+
+Academic Context
+----------------
+Compound multi-unit temporal expressions combine two or more time-unit clauses
+into a single temporal offset. The parsing challenge is threefold:
+
+  1. UNIT BOUNDARY DETECTION: The parser must segment the expression into
+     individual unit clauses without a hard delimiter between them.
+     "1 year 2 months ago" has no separator between "year" and "2".
+
+  2. CONNECTOR HANDLING: The optional word "and" ("1 year and 2 months ago")
+     is syntactically inert — its presence or absence must not change parsing.
+
+  3. RESULT MULTIPLICITY: The API returns one RelativeTime per unit clause.
+     A compound expression with N unit clauses yields N RelativeTime objects.
+     Tests assert len(result) >= 2 for two-unit compounds.
+"""
+import pytest
+from fast_parse_time.api import extract_relative_times
+pytestmark = pytest.mark.xfail(reason='red_team: not yet validated')
+
+# Adjacent frame pairs (ordered largest→smallest)
+_ADJACENT_PAIRS = [
+    ('year','month'),('month','week'),('week','day'),
+    ('day','hour'),('hour','minute'),('minute','second'),
+]
+_DISTANT_PAIRS = [
+    ('year','day'),('year','hour'),('decade','month'),
+    ('year','second'),('month','hour'),
+]
+
+# ── TRUE POSITIVES: 2-unit adjacent pairs × ago ──────────────────────────────
+_TP_2UNIT_AGO = [f'1 {a} 2 {b}s ago' for a,b in _ADJACENT_PAIRS] +                 [f'1 {a} 2 {b}s ago' for a,b in _DISTANT_PAIRS] +                 [f'2 {a}s 3 {b}s ago' for a,b in _ADJACENT_PAIRS] +                 [f'3 {a}s 1 {b} ago' for a,b in _ADJACENT_PAIRS]
+
+@pytest.mark.parametrize('text', _TP_2UNIT_AGO)
+def test_tp_two_unit_ago(text):
+    """Two-unit compound expressions with 'ago'. Expects >= 2 RelativeTime results.
+    Failure: only first unit parsed, second unit dropped."""
+    result = extract_relative_times(text)
+    assert len(result) >= 2
+
+# ── TRUE POSITIVES: with 'and' connector ─────────────────────────────────────
+_TP_AND = [f'1 {a} and 2 {b}s ago' for a,b in _ADJACENT_PAIRS] +           [f'1 year and 2 months and 3 days ago',
+           '2 years and 1 month ago','3 months and 2 weeks ago',
+           '1 week and 4 days ago','2 days and 6 hours ago']
+
+@pytest.mark.parametrize('text', _TP_AND)
+def test_tp_two_unit_with_and_connector(text):
+    """Two-unit compounds with 'and' connector. 'And' is syntactically inert.
+    Failure: 'and' treated as content word breaking the unit-clause segmentation."""
+    result = extract_relative_times(text)
+    assert len(result) >= 2
+
+# ── TRUE POSITIVES: future forms ─────────────────────────────────────────────
+_TP_FUTURE = [f'1 {a} 2 {b}s from now' for a,b in _ADJACENT_PAIRS] +              [f'in 1 {a} 2 {b}s' for a,b in _ADJACENT_PAIRS] +              ['1 year 2 months from now','in 1 year 2 months',
+              '3 months 2 weeks from now','in 2 weeks 5 days',
+              '1 year and 6 months from now','in 2 years 3 months']
+
+@pytest.mark.parametrize('text', _TP_FUTURE)
+def test_tp_compound_future_forms(text):
+    """Compound multi-unit future expressions. Failure: compound future not supported."""
+    result = extract_relative_times(text)
+    assert len(result) >= 2
+
+# ── TRUE POSITIVES: abbreviated units ────────────────────────────────────────
+_TP_ABBR = [
+    '1 yr 2 mos ago','3 mos 2 wks ago','1 yr and 2 mos ago',
+    '2 yrs 6 mos ago','1 mo 2 wks ago','3 wks 4 days ago',
+    '1 yr 2 mos from now','in 1 yr 2 mos',
+]
+@pytest.mark.parametrize('text', _TP_ABBR)
+def test_tp_compound_abbreviated_units(text):
+    """Compound expressions with abbreviated unit forms. Failure: abbreviations break compound parsing."""
+    result = extract_relative_times(text)
+    assert len(result) >= 2
+
+# ── TRUE POSITIVES: 3-unit expressions ───────────────────────────────────────
+_TP_3UNIT = [
+    '1 year 2 months 3 days ago',
+    '2 years 1 month 1 week ago',
+    'in 1 year 2 months 3 days',
+    '1 year 2 months and 3 days ago',
+    '3 days 4 hours 5 minutes ago',
+]
+@pytest.mark.parametrize('text', _TP_3UNIT)
+def test_tp_three_unit_expressions(text):
+    """Three-unit compound expressions. Expects >= 3 RelativeTime results.
+    Failure: third unit dropped during compound parsing."""
+    result = extract_relative_times(text)
+    assert len(result) >= 3
+
+# ── FALSE POSITIVES: non-temporal compound ────────────────────────────────────
+_FP = [
+    '1 dollar 2 cents ago','3 floors 2 rooms back','5 miles 3 blocks from now',
+    '1 foot 2 inches ago','2 pounds 3 ounces back',
+]
+@pytest.mark.parametrize('text', _FP)
+def test_fp_non_temporal_compound(text):
+    """Compound 'N unit N unit ago' with non-temporal units (dollars, floors, miles).
+    Failure: any N-unit compound matched regardless of time-unit membership."""
+    assert len(extract_relative_times(text)) == 0
+
+# ── BOUNDARY ─────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize('text',[
+    '1 year 2 years ago',       # same unit repeated
+    '1 year 0 months ago',      # zero inner unit
+    '2 months 1 year ago',      # reversed order (smaller before larger)
+    '1 and 2 ago',              # connector without units
+    '100 years 50 months ago',  # large values
+])
+def test_boundary_unusual_compounds(text):
+    """Unusual compound forms: repeated units, zero units, reversed order, no units.
+    xfail: behavior for these edge cases is undefined."""
+    extract_relative_times(text)  # should not raise

--- a/tests/red_team/test_rt_eod_eom_eoy.py
+++ b/tests/red_team/test_rt_eod_eom_eoy.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+"""
+Red Team: End-of-Period Abbreviations (eod, eom, eoy)
+Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+
+Academic Context
+----------------
+EOD (end of day), EOM (end of month), EOY (end of year) are compact business
+abbreviations for future temporal references. Their brevity makes them
+particularly susceptible to two attack classes:
+
+  1. FALSE POSITIVE RISK — SUPERSET STRINGS: Any word that contains 'eod',
+     'eom', or 'eoy' as a substring could trigger a false positive if the
+     parser uses substring rather than whole-word matching. The word "decode"
+     contains "eod" as a proper substring (d-e-c-o-d-e → index 3-5 = "ode",
+     but "eod" appears as chars 2-4 of "decode" reversed... actually 'decode'
+     does NOT contain 'eod' literally. However 'period' → 'e-r-i-o-d' does
+     not contain 'eod'. 'diode' → 'd-i-o-d-e' does not contain 'eod'.
+     Testing these confirms the parser uses whole-word boundary matching.
+
+  2. CONCATENATION ATTACK: "eodeom" or "eod/eom" tests whether the parser
+     requires word boundaries around these tokens or allows them to appear
+     adjacent to other characters.
+
+  3. CASE SENSITIVITY: Business usage is mixed — "EOD", "eod", "Eod" all
+     occur. The parser must be case-insensitive for these abbreviations.
+"""
+import pytest
+from fast_parse_time.api import extract_relative_times
+pytestmark = pytest.mark.xfail(reason='red_team: not yet validated')
+
+# ── TRUE POSITIVES: isolated ─────────────────────────────────────────────────
+@pytest.mark.parametrize('text', ['eod','eom','eoy','EOD','EOM','EOY',
+                                   'Eod','Eom','Eoy','eOd','eOm','eOy',
+                                   'EOd','EOm','EOy','EoD','EoM','EoY'])
+def test_tp_isolated_all_cases(text):
+    """EOD/EOM/EOY in all case permutations. Failure: case-sensitive matching."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: sentence embedded ────────────────────────────────────────
+_TP_EMBEDDED = [
+    'please finish by eod','targets are due eom','budget closes eoy',
+    'all reports due EOD','pipeline runs eom','revenue targets set eoy',
+    'finish by eod.','due eom,','closes eoy!',
+    'the PR must be merged EOD','invoices submitted EOM',
+    'headcount finalized EOY','please review by EOD today',
+    'eod is the deadline','eom billing cycle complete',
+    'eoy review scheduled','report needed by eod please',
+]
+@pytest.mark.parametrize('text', _TP_EMBEDDED)
+def test_tp_sentence_embedded(text):
+    """EOD/EOM/EOY embedded in natural business language with punctuation.
+    Failure: surrounding tokens or punctuation prevent matching."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: all three in one string ────────────────────────────────
+def test_tp_all_three_in_one_string_lower():
+    """'eod eom eoy' — all three markers in one string. Expect 3 results."""
+    result = extract_relative_times('eod eom eoy')
+    assert len(result) >= 3
+
+def test_tp_all_three_in_one_string_upper():
+    """'EOD EOM EOY' — all three uppercase. Expect 3 results."""
+    result = extract_relative_times('EOD EOM EOY')
+    assert len(result) >= 3
+
+# ── FALSE POSITIVES: superset strings (word contains eod/eom/eoy as substring) ─
+_FP_SUPERSET = [
+    'aeod','eodx','xeom','eomx','xeoy','eoyx',
+    'eodeom','eomeoy','eodeoy',
+    'AEOD','EODX','XEOM',
+    'EODF','EOMR','EOYA',
+    'reload','commode','decode',  # testing: do these contain eod/eom/eoy? 'reload' no, 'decode' no
+    'geometry','theorem','poem',
+]
+@pytest.mark.parametrize('text', _FP_SUPERSET)
+def test_fp_superset_strings(text):
+    """Strings prefixing/suffixing eod/eom/eoy with extra characters.
+    Tests that the parser uses word-boundary matching, not substring matching.
+    Failure: partial matches on concatenated or extended tokens."""
+    assert len(extract_relative_times(text)) == 0
+
+# ── FALSE POSITIVES: joined with punctuation ─────────────────────────────────
+_FP_JOINED = [
+    'eod/eom','eom-eoy','eod_eom','eod.eom','eod,eom',
+    'EOD/EOM','EOM-EOY',
+]
+@pytest.mark.parametrize('text', _FP_JOINED)
+def test_fp_punctuation_joined(text):
+    """EOD/EOM/EOY tokens joined directly by punctuation without spaces.
+    Whether these should match as individual tokens is ambiguous.
+    xfail: joined forms may or may not be supported."""
+    # Not asserting specific outcome — just must not crash
+    extract_relative_times(text)
+
+# ── BOUNDARY: empty and partial ──────────────────────────────────────────────
+@pytest.mark.parametrize('text', ['','e','eo','od','om','oy'])
+def test_boundary_partial_tokens(text):
+    """Empty string and partial token fragments. Should not match and not crash.
+    Failure: partial fragments matched as temporal."""
+    assert len(extract_relative_times(text)) == 0

--- a/tests/red_team/test_rt_hyphen_month_year.py
+++ b/tests/red_team/test_rt_hyphen_month_year.py
@@ -1,0 +1,858 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+"""
+Red Team: Hyphen-Month-Year Patterns
+======================================
+This module adversarially probes the fast-parse-time parser handling of
+date expressions that join a month name or abbreviation to a two-digit or
+four-digit year using a hyphen delimiter. The canonical forms targeted are:
+
+  Forward (MONTH_YEAR):   Oct-23, Oct-2023, March-2023
+  Reversed (YEAR_MONTH):  23-Oct, 2023-Oct
+  Full month names:       January-2023, December-2023
+
+These patterns are prevalent in:
+  - Financial reporting headers (Jan-24 P&L, Q3-23 summary)
+  - Log file timestamps (Oct-23 audit log)
+  - Abbreviated table column headers (Nov-23 | Dec-23 | Jan-24)
+  - Database exports and ETL pipeline metadata
+
+The primary adversarial challenge is disambiguation from a large class of
+hyphen-joined token pairs that share the same surface structure but carry
+no date meaning:
+  - Day-of-week prefixes: Sun-23, Mon-23, Tue-23
+  - Quarter identifiers: Q1-23, Q2-23, Q3-23, Q4-23
+  - Version strings: v1-23, v2-23, v10-23
+  - Prefix+year compounds: pre-2023, post-2023, non-2023
+
+A secondary challenge is the Unicode hyphen family: the ASCII hyphen-minus
+(U+002D) is the intended delimiter, but typographers frequently substitute
+non-breaking hyphen (U+2011), en-dash (U+2013), em-dash (U+2014), or the
+invisible soft hyphen (U+00AD).
+
+Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+"""
+
+import pytest
+from fast_parse_time import extract_explicit_dates
+
+pytestmark = pytest.mark.xfail(reason='red_team: not yet validated')
+
+
+# ===========================================================================
+# SECTION 1 -- TRUE POSITIVES: ALL 12 ABBREVIATED MONTHS FORWARD (Abbrev-YY)
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Abbreviated month + hyphen + 2-digit year. This is the most compact
+    # MONTH_YEAR format and appears extensively in financial reporting,
+    # spreadsheet column headers, and time-series data.
+    'Jan-23',
+    'Feb-23',
+    'Mar-23',
+    'Apr-23',
+    'May-23',
+    'Jun-23',
+    'Jul-23',
+    'Aug-23',
+    'Sep-23',
+    'Sept-23',
+    'Oct-23',
+    'Nov-23',
+    'Dec-23',
+    # Additional 2-digit year variants
+    'Jan-00',
+    'Jan-99',
+    'Jan-24',
+    'Feb-24',
+    'Mar-24',
+    'Apr-24',
+    'May-24',
+    'Jun-24',
+    'Jul-24',
+    'Aug-24',
+    'Sep-24',
+    'Oct-24',
+    'Nov-24',
+    'Dec-24',
+    # In sentence context
+    'The report for Jan-23 is attached.',
+    'Review the Feb-23 figures.',
+    'Submit by Mar-23 deadline.',
+    'Data from Apr-23 needs review.',
+    'The May-23 audit is complete.',
+    'June invoices: Jun-23.',
+    'Quarterly: Jul-23.',
+    'See Aug-23 summary.',
+    'Filed Sep-23.',
+    'Submitted Oct-23.',
+    'Balance for Nov-23.',
+    'Year-end Dec-23 report.',
+    # Additional year variants
+    'Jan-26',
+    'Dec-36',
+    'Oct-22',
+    'Mar-19',
+    'Jul-15',
+    'Nov-10',
+    'Feb-05',
+    'Apr-00',
+    'Jun-98',
+    'Aug-95',
+    'Sep-90',
+    'May-85',
+])
+def test_true_positive_abbrev_months_forward_2digit(text):
+    """
+    True positive: abbreviated month + hyphen + 2-digit year (forward order).
+
+    Attack vector: The Abbrev-YY format is the most compact written MONTH_YEAR
+    date expression. It is extremely common in financial tables, audit trails,
+    and report headers. The 2-digit year introduces ambiguity about the century
+    (Jan-23 = January 2023 vs January 1923), but within the supported year
+    range [1926, 2036], the century assignment can be inferred by convention.
+
+    Why a parser might fail: The parser may require a 4-digit year and reject
+    2-digit years entirely. Alternatively, the 2-digit year pattern may be
+    matched by a less specific rule that does not validate the month component,
+    or the month abbreviation lookup may be incomplete.
+
+    Failure reveals: The 2-digit year variant of the MONTH_YEAR extractor is
+    absent, or the month abbreviation table is missing entries.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ===========================================================================
+# SECTION 2 -- TRUE POSITIVES: ALL 12 ABBREVIATED MONTHS WITH 4-DIGIT YEAR
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Abbreviated month + hyphen + 4-digit year. The 4-digit year removes
+    # century ambiguity and is the more explicit variant of the format.
+    'Jan-2023',
+    'Feb-2023',
+    'Mar-2023',
+    'Apr-2023',
+    'May-2023',
+    'Jun-2023',
+    'Jul-2023',
+    'Aug-2023',
+    'Sep-2023',
+    'Sept-2023',
+    'Oct-2023',
+    'Nov-2023',
+    'Dec-2023',
+    # Different years across the valid range
+    'Jan-1926',
+    'Dec-2036',
+    'Oct-2024',
+    'Mar-2025',
+    'Jul-2030',
+    'Nov-1980',
+    'Feb-2000',
+    'Apr-1999',
+    'Jun-2010',
+    'Aug-2015',
+    'Sep-2018',
+    'May-2019',
+    # Additional variants
+    'Jan-2024',
+    'Feb-2024',
+    'Mar-2024',
+    'Apr-2024',
+    'May-2024',
+    'Jun-2024',
+    'Jul-2024',
+    'Aug-2024',
+    'Sep-2024',
+    'Oct-2024',
+    'Nov-2024',
+    'Dec-2024',
+    # Sentence embedded
+    'The Jan-2023 report is final.',
+    'See Feb-2023 for prior period.',
+    'The Mar-2023 quarter is closed.',
+    'Apr-2023 data has been reconciled.',
+    'May-2023 invoices are archived.',
+    'Jun-2023 closing balance confirmed.',
+    'Jul-2023 was the peak month.',
+    'Aug-2023 showed a decline.',
+    'Sep-2023 recovered strongly.',
+    'Oct-2023 is the reference period.',
+    'Nov-2023 figures are preliminary.',
+    'Dec-2023 year-end data is final.',
+])
+def test_true_positive_abbrev_months_forward_4digit(text):
+    """
+    True positive: abbreviated month + hyphen + 4-digit year (forward order).
+
+    Attack vector: The Abbrev-YYYY format resolves the century ambiguity of
+    the 2-digit year variant. It is used where precision is required: formal
+    financial statements, database schemas, API date fields. The 4-digit year
+    is also more easily distinguishable from non-date hyphened tokens because
+    few non-date identifiers use 4-digit numeric components.
+
+    Why a parser might fail: The parser handles the 2-digit year case but
+    applies a different (or absent) pattern for the 4-digit year case, or
+    the pattern for 4-digit years incorrectly requires the month to come
+    after the year (YYYY-Abbrev format), causing Abbrev-YYYY to be missed.
+
+    Failure reveals: The 4-digit year variant of the forward-order
+    Abbrev-YYYY pattern is not recognized by the extractor.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ===========================================================================
+# SECTION 3 -- TRUE POSITIVES: ALL 12 ABBREVIATED MONTHS REVERSED (YY-Abbrev)
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Year-first (reversed) format: YY-Abbrev or YYYY-Abbrev. This layout is
+    # common in ISO-influenced date systems and data exports from European systems.
+    '23-Jan',
+    '23-Feb',
+    '23-Mar',
+    '23-Apr',
+    '23-May',
+    '23-Jun',
+    '23-Jul',
+    '23-Aug',
+    '23-Sep',
+    '23-Oct',
+    '23-Nov',
+    '23-Dec',
+    # 4-digit year reversed variants
+    '2023-Jan',
+    '2023-Feb',
+    '2023-Mar',
+    '2023-Apr',
+    '2023-May',
+    '2023-Jun',
+    '2023-Jul',
+    '2023-Aug',
+    '2023-Sep',
+    '2023-Oct',
+    '2023-Nov',
+    '2023-Dec',
+    # Sentence embedded reversed
+    'Data as of 23-Oct is attached.',
+    'Report for 23-Nov is ready.',
+    'Period 2023-Oct closes Friday.',
+    'The 2023-Dec figures are final.',
+    'Audit for 24-Jan completed.',
+    'See 2024-Mar for updated data.',
+    'Baseline: 23-Sep.',
+    'Reference: 2023-Jun.',
+    # Additional reversed variants
+    '24-Jan',
+    '24-Feb',
+    '24-Mar',
+    '24-Apr',
+    '24-May',
+    '24-Jun',
+    '24-Jul',
+    '24-Aug',
+    '24-Sep',
+    '24-Oct',
+    '24-Nov',
+    '24-Dec',
+    '2024-Jan',
+    '2024-Feb',
+    '2024-Mar',
+    '2024-Apr',
+    '2024-May',
+    '2024-Jun',
+    '2024-Jul',
+    '2024-Aug',
+    '2024-Sep',
+    '2024-Oct',
+    '2024-Nov',
+    '2024-Dec',
+])
+def test_true_positive_abbrev_months_reversed(text):
+    """
+    True positive: year + hyphen + abbreviated month (reversed order).
+
+    Attack vector: The reversed YY-Abbrev and YYYY-Abbrev formats. These are
+    used in contexts where lexicographic sorting of date strings should produce
+    chronological order (ISO 8601 motivation). The year-first ordering is
+    standard in database fields, file naming conventions, and European data
+    exports.
+
+    Why a parser might fail: The parser was designed around the forward-order
+    (Abbrev-Year) convention common in English business language and does not
+    have a corresponding reversed-order pattern, or the reversed-order pattern
+    is present but uses different (or absent) year-range validation logic.
+
+    Failure reveals: The YEAR_MONTH extractor path is absent or incomplete,
+    causing all year-first date expressions to be missed.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ===========================================================================
+# SECTION 4 -- TRUE POSITIVES: ALL 12 FULL MONTH NAMES HYPHENATED
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Full month name + hyphen + 4-digit year.
+    'January-2023',
+    'February-2023',
+    'March-2023',
+    'April-2023',
+    'May-2023',
+    'June-2023',
+    'July-2023',
+    'August-2023',
+    'September-2023',
+    'October-2023',
+    'November-2023',
+    'December-2023',
+    # Additional year variants
+    'January-2024',
+    'February-2024',
+    'March-2024',
+    'April-2024',
+    'May-2024',
+    'June-2024',
+    'July-2024',
+    'August-2024',
+    'September-2024',
+    'October-2024',
+    'November-2024',
+    'December-2024',
+    # Sentence embedded
+    'The March-2023 report was submitted.',
+    'See October-2024 for current data.',
+    'Coverage period: January-2024 to December-2024.',
+    'The September-2023 audit found no issues.',
+    'July-2024 is the target completion.',
+    'Filed under November-2023.',
+    'The February-2024 adjustment is pending.',
+    'Effective August-2024 new rates apply.',
+    'June-2023 was the baseline period.',
+    'December-2023 is year-end.',
+    'April-2024 budget was approved.',
+    'May-2023 marked the project start.',
+    # Boundary years
+    'January-1926',
+    'December-2036',
+    'March-1980',
+    'October-2000',
+])
+def test_true_positive_full_month_hyphenated(text):
+    """
+    True positive: full month name + hyphen + 4-digit year.
+
+    Attack vector: The full-name hyphenated MONTH-YEAR format. While less
+    common than the abbreviated form, this pattern appears in formal contexts
+    where abbreviations are discouraged. The parser must recognize full month
+    names (not just abbreviations) in the hyphenated MONTH_YEAR extractor.
+
+    Why a parser might fail: The hyphenated month-year extractor was built
+    primarily for abbreviated month names and does not include full month names
+    in its pattern set, or the full-name pattern is a lower-priority branch
+    that is pre-empted by a more general pattern match.
+
+    Failure reveals: The MONTH_YEAR extractor only handles abbreviated month
+    names and silently rejects spelled-out month names in hyphenated format.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ===========================================================================
+# SECTION 5 -- TRUE POSITIVES: CASE VARIANTS
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Case variation in the abbreviated month component.
+    'OCT-23',
+    'oct-23',
+    'OcT-23',
+    'OCT-2023',
+    'oct-2023',
+    'OcT-2023',
+    'JAN-23',
+    'jan-23',
+    'JaN-23',
+    'DEC-23',
+    'dec-23',
+    'DeC-23',
+    'MAR-2024',
+    'mar-2024',
+    'MaR-2024',
+    'JUL-2024',
+    'jul-2024',
+    'JuL-2024',
+    'NOV-2023',
+    'nov-2023',
+    'NoV-2023',
+    'FEB-23',
+    'feb-23',
+    'FeB-23',
+    'APR-2024',
+    'apr-2024',
+    'ApR-2024',
+    'SEP-23',
+    'sep-23',
+    'SeP-23',
+    'AUG-2024',
+    'aug-2024',
+    'AuG-2024',
+    'JUN-23',
+    'jun-23',
+    'JuN-23',
+    'MAY-23',
+    'may-23',
+    'MaY-23',
+    # Full month name case variants
+    'OCTOBER-2023',
+    'october-2023',
+    'JANUARY-2024',
+    'january-2024',
+    'MARCH-2023',
+    'march-2023',
+    'DECEMBER-2024',
+    'december-2024',
+])
+def test_true_positive_case_variants(text):
+    """
+    True positive: case variants of hyphenated month-year expressions.
+
+    Attack vector: Case variation in month abbreviation spelling. System logs,
+    database exports, and automated report headers frequently produce month
+    abbreviations in all-caps (OCT), all-lowercase (oct), or mixed case (OcT).
+    A parser using case-sensitive string matching will fail on all but the
+    casing it was designed for.
+
+    Why a parser might fail: The month abbreviation lookup table or regex is
+    case-sensitive. This is a particularly common bug when month names are
+    stored as title-cased constants (Oct, Jan, Dec) and compared using ==
+    rather than case-insensitive matching.
+
+    Failure reveals: The hyphenated MONTH_YEAR extractor uses case-sensitive
+    comparison for month name lookup, making it fragile against real-world
+    data sources that normalize to uppercase or lowercase.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ===========================================================================
+# SECTION 6 -- TRUE POSITIVES: SENTENCE EMBEDDED
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    'The report for Oct-23 is ready for review.',
+    'As of 2023-Oct, the project is complete.',
+    'All data from Jan-2024 must be reprocessed.',
+    'Please review the Dec-23 closing figures.',
+    'Coverage period runs from Jan-23 to Dec-23.',
+    'The Nov-2023 audit revealed three discrepancies.',
+    'Submit your Mar-24 expense report by the 5th.',
+    'The Jul-2024 projection has been updated.',
+    'Historical baseline set at Sep-22.',
+    'The 2024-Feb data has been reconciled.',
+    'Effective 2024-Jan new pricing applies.',
+    'See the attached May-2024 summary.',
+    'Period ending Jun-24 shows 12% growth.',
+    'The Aug-2023 figures were restated.',
+    'From Feb-2024 to August-2024 revenue grew.',
+    'The October-2024 draft is under review.',
+    'Q3 results: Jul-24, Aug-24, Sep-24.',
+    'Invoices dated Oct-2023 require resubmission.',
+    'All June-2024 transactions are reconciled.',
+    'The March-2024 and April-2024 reports are merged.',
+    'For period ending 2024-Jun please review.',
+    'Compare 2023-Nov to 2024-Nov performance.',
+    'The 23-Jan report is late.',
+    'Data for 24-Dec is under embargo.',
+    'Reference period: 2023-Mar to 2024-Mar.',
+])
+def test_true_positive_sentence_embedded(text):
+    """
+    True positive: hyphenated month-year expressions in sentence context.
+
+    Attack vector: Hyphenated month-year tokens appearing within a full
+    natural-language sentence. The surrounding sentence context introduces
+    additional hyphens (from compound adjectives, hyphenated words, etc.)
+    that may confuse a parser looking for hyphens as date delimiters.
+
+    Why a parser might fail: The parser uses lookahead or lookbehind
+    assertions anchored to whitespace that do not correctly handle cases
+    where the date token is followed by a comma, period, or other
+    punctuation rather than whitespace.
+
+    Failure reveals: The boundary detection logic is sensitive to
+    punctuation that immediately follows the date token, causing the
+    parser to miss dates at the end of a clause.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ===========================================================================
+# SECTION 7 -- FALSE POSITIVES: NON-DATE HYPHENATED TOKENS
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Day-of-week abbreviations followed by a 2-digit number.
+    'Sun-23 is not a date.',
+    'Mon-23 is a day label.',
+    'Tue-23 label.',
+    'Wed-23 identifier.',
+    'Thu-23 marker.',
+    'Fri-23 tag.',
+    'Sat-23 prefix.',
+    'Sun-2023 day label.',
+    'Mon-2024 identifier.',
+    'Tue-2024 tag.',
+    # Quarter identifiers: Q1-23, Q2-23, Q3-23, Q4-23.
+    'Q1-23 results are attached.',
+    'Q2-23 revenue grew 5%.',
+    'Q3-23 data is under review.',
+    'Q4-23 was the strongest quarter.',
+    'Q1-2023 earnings report.',
+    'Q2-2024 projections.',
+    'Q3-2024 actual vs budget.',
+    'Q4-2024 forecast.',
+    # Version identifiers with letter prefix: v1-23, v2-23.
+    'v1-23 of the spec.',
+    'v2-23 fixes the bug.',
+    'v10-23 is the LTS release.',
+    'v1-2023 is deprecated.',
+    # Prefix+year compounds.
+    'The pre-2023 policy applies.',
+    'Post-2023 regulations are stricter.',
+    'Non-2023 data is archived.',
+    'Anti-2023 measures were repealed.',
+    'Re-2023 filing is required.',
+    'Mid-2023 saw the peak.',
+    'Late-2023 data is available.',
+    'Early-2023 baseline established.',
+    'Pre-2024 contracts are grandfathered.',
+    'Post-2024 invoices use new rates.',
+    # Month abbreviations used as word stems
+    'Mar-ket analysis is attached.',
+    'Jun-ction of routes is at mile 42.',
+    'Aug-mented reality demo scheduled.',
+    'Oct-ane rating is 91.',
+    'Dec-imal precision matters.',
+    'Nov-el approach tried.',
+    'Feb-rile response noted.',
+    # Generic hyphenated numeric identifiers
+    'ID-23 was assigned.',
+    'REF-23 must be quoted.',
+    'CODE-2023 is invalid.',
+    'TAG-23 applied.',
+    # Same string on both sides of hyphen
+    'Oct-Oct is not a date.',
+    'Jan-Jan makes no sense.',
+    # Year-year ranges (not month-year)
+    'The 2023-2024 fiscal year budget.',
+    'Revenue for 2022-2023 was flat.',
+    # Non-month word prefixes with year
+    'feature-2023 branch merged.',
+    'hotfix-2024 deployed.',
+    'PROJ-2023 ticket resolved.',
+    'BUG-2024 is critical.',
+    'update-2023 patch applied.',
+    'release-2024 notes attached.',
+])
+def test_false_positive_non_date_hyphenated_tokens(text):
+    """
+    False positive guard: non-date hyphenated tokens must not be classified
+    as dates.
+
+    Attack vector: A large variety of hyphen-joined token pairs share the
+    surface structure of hyphenated month-year expressions:
+      - Day-of-week abbreviations (Sun, Mon, Tue, ...) followed by a year
+      - Quarter labels (Q1, Q2, Q3, Q4) followed by a year
+      - Version prefixes (v1, v2, v10) followed by a year
+      - Common English word prefixes (pre-, post-, non-, mid-, late-, early-)
+        followed by a year
+      - Month abbreviations used as word stems (Mar-ket, Jun-ction)
+
+    The parser must use a whitelist of valid month abbreviations (Jan, Feb,
+    Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec) as the discriminating
+    criterion. Any left-side token that is NOT in this whitelist should not
+    trigger a MONTH_YEAR match.
+
+    Why a parser might fail: The parser applies a too-broad pattern that
+    matches any 2-3 letter alphabetic prefix followed by a hyphen and a
+    2-4 digit number, without restricting the prefix to the month name
+    whitelist.
+
+    Failure reveals: The month-name whitelist is either absent (pure shape
+    matching) or has a logic bug that allows non-month prefixes to match.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ===========================================================================
+# SECTION 8 -- BOUNDARY: YEAR RANGE FOR HYPHENATED MONTH-YEAR
+# ===========================================================================
+
+@pytest.mark.parametrize('text, expect_match', [
+    # The hyphenated month-year extractor must apply the same year-range
+    # constraint [1926, 2036] as all other date extractors.
+    ('Jan-1926', True),
+    ('Dec-2036', True),
+    ('Oct-2024', True),
+    ('Mar-1980', True),
+    ('Jan-1925', False),
+    ('Dec-2037', False),
+    ('Oct-1800', False),
+    ('Mar-2100', False),
+    # 2-digit boundary tests
+    ('Jan-26', True),
+    ('Dec-36', True),
+    ('Oct-24', True),
+    # Degenerate cases
+    ('Oct-Oct', False),
+    ('2023-2024', False),
+    ('Jan-Jan', False),
+    # Additional boundary probes
+    ('Feb-1926', True),
+    ('Nov-2036', True),
+    ('Jul-1927', True),
+    ('Aug-2035', True),
+    ('Sep-1924', False),
+    ('Oct-2038', False),
+])
+def test_boundary_year_range_hyphenated(text, expect_match):
+    """
+    Boundary: year range enforcement for hyphenated month-year expressions.
+
+    Attack vector: Hyphenated month-year expressions with year values at or
+    beyond the documented supported range [1926, 2036]. The extractor must
+    apply the same range constraint as all other date extractors. Also tests
+    degenerate cases where the right-side operand is not a numeric year.
+
+    Why a parser might fail: The hyphenated month-year extractor was
+    implemented independently of the numeric date extractor and does not
+    share the year-range validation logic. As a result, it may accept year
+    values that all other extractors would reject (e.g., Jan-1800 or
+    Oct-2100), leading to inconsistent parser behavior.
+
+    Failure reveals: The year-range guard is absent or incorrectly applied
+    in the hyphenated month-year extractor, causing range violations to
+    propagate to the output.
+    """
+    result = extract_explicit_dates(text)
+    if expect_match:
+        assert len(result) > 0, f'Expected match for: {text!r}'
+    else:
+        assert len(result) == 0, f'Expected no match for: {text!r}'
+
+
+# ===========================================================================
+# SECTION 9 -- UNICODE: NON-ASCII HYPHEN VARIANTS
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Non-breaking hyphen (U+2011): visually identical to regular hyphen.
+    # Inserted by word processors to prevent line breaks at hyphens.
+    'Oct‑23',
+    'Oct‑2023',
+    '2023‑Oct',
+    'Jan‑24',
+    'Mar‑2024',
+    # En-dash (U+2013): slightly wider than hyphen, common in typography.
+    'Oct–23',
+    'Oct–2023',
+    '2023–Oct',
+    'Jan–24',
+    'Mar–2024',
+    # Em-dash (U+2014): significantly wider, used for parenthetical phrases.
+    'Oct—23',
+    'Oct—2023',
+    '2023—Oct',
+    'Jan—24',
+    # Soft hyphen (U+00AD): invisible in rendering, typesetting line-break hint.
+    'Oct­23',
+    'Oct­2023',
+    '2023­Oct',
+    'Jan­24',
+    # Figure dash (U+2012): similar in width to en-dash.
+    'Oct‒23',
+    'Oct‒2023',
+    # Horizontal bar (U+2015): longer than em-dash.
+    'Oct―23',
+    'Oct―2023',
+])
+def test_unicode_hyphen_variants(text):
+    """
+    Unicode attack: non-ASCII hyphen substitutions in hyphenated month-year
+    expressions.
+
+    Attack vector: The Unicode standard includes multiple characters that
+    are visually indistinguishable from or resemble the ASCII hyphen-minus
+    (U+002D):
+      - Non-breaking hyphen (U+2011): identical appearance, prevents line break
+      - En-dash (U+2013): slightly wider, common word processor substitution
+      - Em-dash (U+2014): significantly wider, parenthetical use
+      - Soft hyphen (U+00AD): invisible, typesetting line-break hint
+      - Figure dash (U+2012): financial use, width of a digit
+      - Horizontal bar (U+2015): linguistic use
+
+    These substitutions can appear in word processor output, PDF extraction
+    artifacts, HTML entity encoding, and adversarial inputs.
+
+    Why a parser might fail: The parser regex is anchored to the ASCII
+    hyphen-minus character class ([-]) and does not include Unicode hyphen
+    variants. Text normalized from word processor or PDF sources will
+    silently fail to match.
+
+    Failure reveals: The parser raises an unhandled exception on Unicode
+    input, or the parser silently hangs on Unicode hyphen injection.
+    """
+    try:
+        result = extract_explicit_dates(text)
+        assert isinstance(result, dict)
+    except Exception as exc:
+        pytest.fail(
+            f'Parser raised exception on Unicode hyphen input: {exc!r}\nInput: {text!r}'
+        )
+
+
+# ===========================================================================
+# SECTION 10 -- COMPREHENSIVE: ALL MONTHS ACROSS ALL VALID YEARS (SWEEP)
+# ===========================================================================
+
+@pytest.mark.parametrize('month_abbrev', [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+])
+@pytest.mark.parametrize('year', [1926, 1950, 1980, 2000, 2010, 2020, 2024, 2036])
+def test_true_positive_all_months_all_valid_years(month_abbrev, year):
+    """
+    True positive: comprehensive sweep of all month abbreviations across
+    representative valid years.
+
+    Attack vector: Combinatorial coverage of the month-year matrix. Bugs in
+    the hyphenated MONTH_YEAR extractor may be month-specific (e.g., May
+    conflicting with the modal-verb suppression rule) or year-specific (e.g.,
+    boundary years at the edge of the valid range).
+
+    This parametrized test generates 12 months x 8 years = 96 test cases,
+    ensuring that no month-year combination within the valid range is missed
+    by the extractor.
+
+    Why a parser might fail: A month-specific suppression rule (e.g., May
+    is suppressed because it appears frequently as a modal verb) may be
+    applied even in hyphenated context where May-2024 is unambiguous.
+    Alternatively, a year-range boundary check with an off-by-one error may
+    incorrectly reject the boundary years (1926, 2036).
+
+    Failure reveals: Either a month-specific suppression is overly broad
+    (catching May-2024 in addition to bare May as a modal verb), or the
+    year-range check has an off-by-one at the boundary values.
+    """
+    text = f'The {month_abbrev}-{year} report is ready.'
+    result = extract_explicit_dates(text)
+    assert len(result) > 0, (
+        f'Expected match for {month_abbrev}-{year} in: {text!r}'
+    )
+
+
+# ===========================================================================
+# SECTION 11 -- ADJACENT CONTEXT: MULTIPLE DATES IN ONE STRING
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    'Compare Jan-23 to Jan-24.',
+    'From Feb-2023 to Feb-2024.',
+    'Q1 covers Jan-24, Feb-24, Mar-24.',
+    'Period: Oct-23 through Dec-23.',
+    'The trend from 2023-Jan to 2023-Dec is positive.',
+    'See both Jun-2023 and Jun-2024 for comparison.',
+    'Monthly data: Jan-24, Feb-24, Mar-24, Apr-24.',
+    'H1 2024: Jan-2024 through Jun-2024.',
+    'H2 2023: Jul-2023 through Dec-2023.',
+    'YoY comparison: Oct-2023 vs Oct-2024.',
+    'Compare Q1: Jan-24, Feb-24, Mar-24 with prior.',
+    'Period: 2023-Jan through 2023-Dec inclusive.',
+])
+def test_true_positive_multiple_dates_in_string(text):
+    """
+    True positive: multiple hyphenated month-year dates in a single string.
+
+    Attack vector: A string containing multiple date references. The parser
+    must extract all occurrences without the first match consuming the entire
+    string or without state contamination between matches.
+
+    Why a parser might fail: The parser uses a non-overlapping single-pass
+    regex that returns only the first match, or the parser consumes whitespace
+    greedily after the first match, preventing subsequent matches.
+
+    Failure reveals: The multi-match iteration logic is absent or incorrectly
+    implemented, causing only the first date to be returned.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) >= 2, f'Expected at least 2 date matches in: {text!r}'
+
+
+# ===========================================================================
+# SECTION 12 -- FALSE POSITIVES: ADDITIONAL EDGE CASES
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Git branch names with year fragments
+    'Branch feature-2023 was merged.',
+    'Hotfix hotfix-2024 deployed.',
+    # JIRA-style ticket IDs
+    'Ticket PROJ-2023 is resolved.',
+    'Issue BUG-2024 is critical.',
+    # Hyphenated year ranges
+    'The 2023-2024 fiscal year budget.',
+    'Revenue for 2022-2023 was flat.',
+    # Generic word-year compounds
+    'The update-2023 patch was applied.',
+    'The release-2024 notes are attached.',
+    'See doc-2023 for background.',
+    'File backup-2024 is stored.',
+    # Numbers on both sides of hyphen (no alphabetic month component)
+    'Record 01-23 was processed.',
+    'ID 99-23 is expired.',
+    'Code 12-23 is active.',
+    # Three-component sequences that look like date fragments
+    'Ref 23-45-67 is incorrect.',
+    'Code A23-B45 is a product ID.',
+    # Year as left operand with non-month right operand
+    '2023-Q1 financial data.',
+    '2024-H2 is our target.',
+    '2023-YTD performance.',
+    '2024-FY results.',
+])
+def test_false_positive_additional_non_date_constructs(text):
+    """
+    False positive guard: additional non-date hyphenated constructs.
+
+    Attack vector: Additional categories of hyphen-joined strings that appear
+    frequently in technical and business text without date meaning:
+      - Source control branch names (feature-2023, hotfix-2024)
+      - Issue tracker IDs (PROJ-2023, BUG-2024)
+      - Fiscal year ranges (2023-2024)
+      - Generic word-year compounds (update-2023, backup-2024)
+      - Pure numeric pairs (01-23, 99-23)
+      - Business period labels (2023-Q1, 2024-H2, 2023-YTD)
+
+    Why a parser might fail: The parser left-operand whitelist may be
+    applied only to alphabetic tokens and may inadvertently match numeric
+    tokens on the left side (01-23 could be misread as day-year if the
+    month whitelist lookup falls back to a numeric interpretation).
+
+    Failure reveals: The left-side discriminator is either absent, not
+    anchored to word boundaries, or falls back to a numeric interpretation
+    when no month name is recognized.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0

--- a/tests/red_team/test_rt_iso8601.py
+++ b/tests/red_team/test_rt_iso8601.py
@@ -1,0 +1,862 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+"""
+Red Team Test Suite -- ISO 8601 Datetime Strings
+================================================
+Target function : extract_explicit_dates(text: str) -> Dict[str, str]
+Target patterns : 2017-02-03T09:04:08Z, timezone offsets, fractional seconds
+
+Related GitHub Issue:
+    #43 https://github.com/craigtrim/fast-parse-time/issues/43
+
+ATTACK SURFACE OVERVIEW
+------------------------
+ISO 8601 is a rich, layered standard. A naive regex that matches the basic
+``YYYY-MM-DDTHH:MM:SSZ`` form may:
+
+  1. Miss legitimate variants: timezone offsets (+05:30), fractional seconds
+     (.123 or ,123 per the standard comma-allowed alternative), reduced
+     precision forms, and ordinal/week dates.
+
+  2. Over-match look-alikes: ISO 8601 *duration* strings (PT1H30M), ISO 8601
+     *interval* strings using slash notation (2024-01-01/2024-03-31),
+     version strings (v2024-03T1), and ticket identifiers (ticket-2024-01T).
+
+  3. Break silently on out-of-range field values: month 13, day 0, hour 24,
+     and leap-second (60th second) which are defined in some contexts but
+     invalid in others.
+
+  4. Fail on Unicode homoglyphs: fullwidth T, fullwidth colon, fullwidth Z,
+     or Arabic-Indic digits that are visually identical but byte-different.
+
+Each parametrize section isolates one attack dimension so that a failing test
+pinpoints the exact gap.
+
+XFAIL STRATEGY
+--------------
+All tests carry ``pytestmark = pytest.mark.xfail`` so the suite remains green
+while the implementation is incomplete. An unexpected pass (xpass) is a
+promotion candidate -- move that case to the canonical test suite once the
+behaviour is confirmed intentional and desired.
+
+TRUE POSITIVE TESTS  ->  assert len(result) > 0  (parser must find something)
+FALSE POSITIVE TESTS ->  assert len(result) == 0  (parser must find nothing)
+BOUNDARY TESTS       ->  xfail; outcome documents current tolerance
+UNICODE TESTS        ->  xfail; outcome documents normalisation behaviour
+"""
+
+import pytest
+from fast_parse_time.api import extract_explicit_dates
+
+# Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+
+pytestmark = pytest.mark.xfail(reason='red_team: not yet validated')
+
+
+# ============================================================================
+# SECTION 1 -- TRUE POSITIVES: BASIC UTC (Z suffix)
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Core RFC 3339 / ISO 8601 combined datetimes in UTC.
+    # Every entry has a valid year, month, day, hour, minute, second and the
+    # literal 'Z' suffix indicating UTC (zero-offset). A robust parser must
+    # recognise all of these as explicit date references.
+    '2024-01-01T00:00:00Z',
+    '2024-06-15T12:30:45Z',
+    '2024-12-31T23:59:59Z',
+    '2017-02-03T09:04:08Z',    # original motivating example from issue #43
+    '2000-01-01T00:00:00Z',    # Y2K boundary
+    '1999-12-31T23:59:59Z',    # one second before Y2K
+    '2020-02-29T12:00:00Z',    # leap day 2020
+    '2024-02-29T00:00:00Z',    # leap day 2024
+    '2023-03-26T01:00:00Z',    # DST changeover (UTC unaffected, but a real event)
+    '2023-10-29T01:00:00Z',    # DST end (UTC still valid)
+    '2024-03-15T14:30:00Z',
+    '2024-07-04T17:00:00Z',
+    '2024-11-28T08:00:00Z',
+    '2021-09-11T08:46:00Z',
+    '2024-01-15T09:00:00Z',
+    '2024-02-14T18:00:00Z',
+    '2024-05-01T00:00:00Z',
+    '2024-08-31T23:00:00Z',
+    '2024-09-30T12:00:00Z',
+    '2024-10-31T06:00:00Z',
+    '2026-01-01T00:00:00Z',
+    '2025-06-30T15:45:00Z',
+    '2030-12-31T23:59:59Z',
+    '1970-01-01T00:00:00Z',    # Unix epoch
+    '2038-01-19T03:14:07Z',    # 32-bit Unix timestamp overflow boundary
+    '2001-09-11T12:46:00Z',
+    '2004-12-26T00:58:53Z',
+    '2011-03-11T05:46:23Z',
+    '2019-04-10T21:00:00Z',
+    '2022-02-24T04:00:00Z',
+    '1926-01-01T00:00:00Z',    # parser min-year boundary (if applicable)
+    '2036-12-31T23:59:59Z',    # parser max-year boundary (if applicable)
+])
+def test_iso_basic_utc_true_positive(text):
+    """
+    Attack vector: well-formed ISO 8601 datetime strings with UTC ('Z') suffix.
+
+    Why a parser might fail: if the regex only handles the specific example
+    '2017-02-03T09:04:08Z' and was hand-crafted rather than generalised, then
+    variations in year, month, day, or time component will silently fall through.
+    Leap-day entries (2020-02-29, 2024-02-29) are particularly telling: a parser
+    that validates the calendar date strictly will reject them if leap-year logic
+    is absent; one that does not validate dates at all will accept everything
+    including invalid dates like 2023-02-29.
+
+    What failure reveals: the parser does not recognise basic UTC ISO datetimes
+    as explicit date references, which is the most fundamental ISO 8601 gap.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ============================================================================
+# SECTION 2 -- TRUE POSITIVES: TIMEZONE OFFSETS
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # ISO 8601 allows numeric timezone offsets in place of 'Z'.
+    # The offset is appended directly after the time: +HH:MM or -HH:MM.
+    # A parser that only looks for the literal 'Z' character will miss all of
+    # these, even though they are equally valid ISO 8601 datetimes.
+    '2024-01-01T00:00:00+00:00',    # UTC expressed as numeric offset
+    '2024-06-15T12:30:45+01:00',    # British Summer Time
+    '2024-03-15T08:00:00+05:30',    # India Standard Time (half-hour offset)
+    '2024-07-04T12:00:00+09:30',    # Australia Central Standard Time
+    '2024-11-01T07:00:00+14:00',    # Line Islands -- extreme eastern offset
+    '2024-01-15T10:00:00-05:00',    # Eastern Standard Time
+    '2024-06-20T09:00:00-07:00',    # Mountain Daylight Time
+    '2024-08-15T11:30:00-08:00',    # Pacific Standard Time
+    '2024-02-29T00:00:00-12:00',    # extreme western offset (Baker Island)
+    '2017-02-03T09:04:08+00:00',    # motivating example with numeric UTC offset
+    '2017-02-03T09:04:08+05:30',    # motivating example with India offset
+    '2017-02-03T09:04:08-05:00',    # motivating example with US Eastern offset
+    '2024-01-01T00:00:00+02:00',
+    '2024-01-01T00:00:00+03:00',
+    '2024-01-01T00:00:00+04:00',
+    '2024-01-01T00:00:00+06:00',
+    '2024-01-01T00:00:00+07:00',
+    '2024-01-01T00:00:00+08:00',
+    '2024-01-01T00:00:00+09:00',
+    '2024-01-01T00:00:00+10:00',
+    '2024-01-01T00:00:00+11:00',
+    '2024-01-01T00:00:00+12:00',
+    '2024-01-01T00:00:00-01:00',
+    '2024-01-01T00:00:00-02:00',
+    '2024-01-01T00:00:00-03:00',
+    '2024-01-01T00:00:00-04:00',
+    '2024-01-01T00:00:00-06:00',
+    '2024-01-01T00:00:00-09:00',
+    '2024-01-01T00:00:00-10:00',
+    '2024-01-01T00:00:00-11:00',
+    '2024-06-15T23:30:00+05:45',    # Nepal Time -- 45-minute offset
+    '2024-06-15T23:30:00+08:45',    # Australian Central Western Standard Time
+    '2024-06-15T23:30:00+09:30',
+    '2024-03-15T14:30:00+05:30',
+    '2024-09-22T06:00:00-06:00',
+    '2024-12-25T00:00:00+12:45',    # Chatham Islands (UTC+12:45)
+    '2024-07-04T16:00:00-04:30',    # historical Venezuela Standard Time
+    '2023-11-05T01:00:00-08:00',
+    '2023-03-12T02:00:00-07:00',
+    '2024-10-27T02:00:00+01:00',
+    '2024-06-30T12:00:00+05:30',
+    '2024-09-15T00:00:00-03:00',
+    '2026-01-01T00:00:00+01:00',
+    '2025-12-31T23:59:59-05:00',
+    '2030-06-15T08:00:00+09:00',
+    '1970-01-01T00:00:00+00:00',    # Unix epoch with numeric UTC offset
+])
+def test_iso_timezone_offset_true_positive(text):
+    """
+    Attack vector: ISO 8601 datetimes with explicit numeric timezone offsets.
+
+    Why a parser might fail: a regex anchored on the literal character 'Z' will
+    not match '+00:00' even though the two are semantically identical (both
+    represent UTC). More exotic offsets like +05:30 or +14:00 extend this gap
+    further. A parser that only anchors on Z will miss the majority of real-world
+    ISO timestamps found in API payloads, log files, and database exports.
+
+    The half-hour and 45-minute offsets (+05:30, +05:45, +09:30, +08:45) are
+    particularly important: a regex that only allows two-digit hour offsets
+    followed by ':00' will fail to match them, despite their being unambiguous
+    and common in production traffic from India, Nepal, and Australia.
+
+    What failure reveals: the parser's ISO 8601 support is partial -- it handles
+    only the UTC shorthand and not the full offset grammar defined in RFC 3339.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+
+# ============================================================================
+# SECTION 3 -- TRUE POSITIVES: FRACTIONAL SECONDS (DOT separator)
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # ISO 8601 section 4.2.2.4 permits a decimal fraction on the seconds (or
+    # minutes or hours) component, separated by a full stop (.) or comma (,).
+    # A parser that requires exactly HH:MM:SS before the timezone suffix will
+    # reject all fractional-second variants.
+    '2024-01-01T00:00:00.1Z',
+    '2024-01-01T00:00:00.12Z',
+    '2024-01-01T00:00:00.123Z',
+    '2024-01-01T00:00:00.1234Z',
+    '2024-01-01T00:00:00.12345Z',
+    '2024-01-01T00:00:00.123456Z',    # microsecond precision (Python datetime default)
+    '2024-01-01T00:00:00.999Z',
+    '2024-01-01T00:00:00.999999Z',
+    '2017-02-03T09:04:08.000Z',       # motivating example with zero fraction
+    '2017-02-03T09:04:08.500Z',       # motivating example with half-second
+    '2017-02-03T09:04:08.123456Z',    # motivating example microsecond precision
+    '2024-06-15T12:30:45.001Z',
+    '2024-06-15T12:30:45.999Z',
+    '2024-06-15T12:30:45.0Z',
+    '2024-06-15T12:30:45.00Z',
+    '2024-12-31T23:59:59.999999Z',
+    '2024-03-15T08:00:00.100+05:30',  # fraction + offset combined
+    '2024-03-15T08:00:00.250-05:00',
+    '2024-03-15T08:00:00.750+00:00',
+    '2024-11-28T08:00:00.001Z',
+    '2024-09-30T12:00:00.050Z',
+    '2024-07-04T17:00:00.500Z',
+    '2020-02-29T12:00:00.123Z',       # leap day with fraction
+    '2000-01-01T00:00:00.0Z',
+    '1970-01-01T00:00:00.000Z',
+    '2026-06-15T12:30:45.678Z',
+    '2028-02-29T00:00:00.999Z',       # leap day 2028 with fraction
+    '2030-01-01T00:00:00.100Z',
+    '2024-08-15T11:30:00.250-08:00',
+    '2024-04-30T23:59:59.001Z',
+])
+def test_iso_fractional_seconds_dot_true_positive(text):
+    """
+    Attack vector: ISO 8601 datetimes with dot-separated fractional seconds.
+
+    Why a parser might fail: a regex that terminates the seconds field with a
+    fixed ``\d{2}`` group and then expects ``[Z+-]`` immediately will fail to
+    advance past the decimal point. Even if the regex uses a greedy quantifier
+    on the seconds, it may not account for the fractional part followed by a
+    timezone designator.
+
+    PostgreSQL returns timestamps in the form '2024-01-01T00:00:00.123456+00:00',
+    AWS CloudWatch uses '2024-01-01T00:00:00.001Z', and Python's own
+    ``datetime.isoformat()`` produces '2024-01-01T00:00:00.123456'. All of these
+    will be silently dropped by a parser without fractional-second support.
+
+    The number of fractional digits varies from 1 (tenths) to 6 (microseconds).
+    Production systems emit all widths, so the regex must use a variable-width
+    quantifier on the fraction group (e.g., ``\.\d+`` or ``\.\d{1,9}``).
+
+    What failure reveals: the parser drops sub-second precision timestamps, which
+    are ubiquitous in structured logs and database timestamp columns.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ============================================================================
+# SECTION 4 -- TRUE POSITIVES: FRACTIONAL SECONDS (COMMA separator)
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # ISO 8601 section 4.2.2.4 explicitly states that the decimal sign shall be
+    # either a comma or a full stop. European systems frequently use the comma form.
+    '2024-01-01T00:00:00,1Z',
+    '2024-01-01T00:00:00,12Z',
+    '2024-01-01T00:00:00,123Z',
+    '2024-01-01T00:00:00,999Z',
+    '2024-01-01T00:00:00,123456Z',
+    '2017-02-03T09:04:08,000Z',
+    '2017-02-03T09:04:08,500Z',
+    '2024-06-15T12:30:45,001Z',
+    '2024-06-15T12:30:45,999Z',
+    '2024-12-31T23:59:59,999999Z',
+    '2024-03-15T08:00:00,100+05:30',
+    '2024-03-15T08:00:00,250-05:00',
+    '2020-02-29T12:00:00,123Z',
+    '2000-01-01T00:00:00,0Z',
+    '1970-01-01T00:00:00,000Z',
+    '2026-06-15T12:30:45,678Z',
+    '2030-01-01T00:00:00,001Z',
+    '2024-09-15T14:22:33,456Z',
+    '2025-03-20T10:00:00,500+02:00',
+    '2028-11-11T11:11:11,111Z',
+])
+def test_iso_fractional_seconds_comma_true_positive(text):
+    """
+    Attack vector: ISO 8601 datetimes with comma-separated fractional seconds.
+
+    Why a parser might fail: English-language regex writers rarely think of comma
+    as a decimal separator. A regex that uses ``\.`` for the decimal point will
+    not match ``,``. This gap causes silent data loss when timestamps arrive from
+    European-locale systems or certain database drivers (e.g., MySQL DATETIME
+    exported through ODBC drivers with European locale settings, or timestamps
+    originating from SAP or German-locale Java applications).
+
+    ISO 8601 section 4.2.2.4 says: "The decimal sign is a comma or a full stop
+    (according to the preference of the user)." A parser that ignores this is only
+    half compliant.
+
+    What failure reveals: the parser is not ISO 8601 compliant in its treatment of
+    the decimal separator, which is a subtle but real interoperability defect.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ============================================================================
+# SECTION 5 -- TRUE POSITIVES: SENTENCE EMBEDDED
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Real-world inputs arrive embedded in natural-language sentences or structured
+    # log lines. The parser must handle leading/trailing prose, punctuation adjacent
+    # to the timestamp, and mid-sentence placement.
+    'the event at 2024-03-15T14:30:00Z was critical',
+    'logged at 2017-02-03T09:04:08Z by the system',
+    'between 2024-01-01T00:00:00Z and 2024-12-31T23:59:59Z',
+    'ERROR 2024-06-15T12:30:45Z connection refused',
+    'deployed on 2024-07-04T17:00:00Z successfully',
+    'timestamp: 2024-08-15T11:30:00-08:00 -- user logged in',
+    'created_at=2024-09-01T09:00:00Z, updated_at=2024-09-02T10:00:00Z',
+    'the server restarted at 2024-01-15T03:00:00+00:00.',
+    'alert fired (2024-11-28T08:00:00Z) -- disk usage 95%',
+    'effective from 2024-01-01T00:00:00Z through 2026-12-31T23:59:59Z',
+    'start: 2024-03-01T08:00:00Z; end: 2024-03-01T17:00:00Z',
+    '2024-05-20T15:00:00Z is the submission deadline',
+    'we received 2024-02-29T00:00:00Z (leap day) correctly',
+    'backup completed 2024-06-15T12:30:45.123Z without errors',
+    'job ran from 2024-01-01T06:00:00+05:30 to noon',
+    'event_time:2024-10-31T00:00:00Z,severity:HIGH',
+    '[2024-12-25T00:00:00Z] christmas deployment',
+    'version bump at 2024-09-15T14:22:33Z and tested',
+    'prior to 2024-01-01T00:00:00Z the system was down',
+    'after 2023-12-31T23:59:59Z the new rules apply',
+    'scheduled for 2024-06-30T23:59:59Z before rollover',
+    'incident opened 2024-04-15T09:30:00+01:00, closed 2024-04-15T11:45:00+01:00',
+    'THE INCIDENT OCCURRED AT 2024-03-15T14:30:00Z IN PRODUCTION',
+    'Incident: 2024-07-04T17:00:00Z, severity: critical',
+    '[INFO] 2024-01-15T09:00:00Z server started',
+    '[ERROR] 2024-06-15T12:30:45.123Z exception thrown',
+    '[WARN] 2024-09-30T00:00:00+05:30 threshold exceeded',
+    'commit 2024-08-01T12:00:00Z merged to main',
+    'patch released at 2024-11-15T08:00:00Z addresses CVE-2024-1234',
+    'see audit log entry from 2025-01-01T00:00:00Z onwards',
+])
+def test_iso_sentence_embedded_true_positive(text):
+    """
+    Attack vector: ISO 8601 timestamps embedded in natural-language or structured prose.
+
+    Why a parser might fail: a regex anchored with ``^`` or ``$`` will only match
+    when the timestamp is the entire input string. Real log lines have prefixes
+    (log level, module name), suffixes (message text), or surround the timestamp
+    with punctuation (colons, brackets, parentheses).
+
+    Log aggregation systems (Splunk, Elasticsearch, Loki) pass raw log lines
+    containing timestamps embedded in structured text. A parser that cannot
+    locate the timestamp within prose will fail to function in those contexts.
+
+    What failure reveals: the parser cannot extract timestamps from real log lines,
+    limiting its practical utility to artificially clean inputs.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ============================================================================
+# SECTION 6 -- TRUE POSITIVES: BOUNDARY DATES (valid calendar extremes)
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Calendar extremes that stress-test the regex date-component ranges.
+    '2024-01-01T00:00:00Z',      # January 1 -- start of year
+    '2024-12-31T23:59:59Z',      # December 31 -- end of year
+    '2024-01-31T23:59:59Z',      # January 31 -- valid 31-day month
+    '2024-03-31T23:59:59Z',      # March 31
+    '2024-05-31T23:59:59Z',      # May 31
+    '2024-07-31T23:59:59Z',      # July 31
+    '2024-08-31T23:59:59Z',      # August 31
+    '2024-10-31T23:59:59Z',      # October 31
+    '2024-02-29T23:59:59Z',      # February 29 -- leap day (2024 IS a leap year)
+    '2023-02-28T23:59:59Z',      # February 28 -- last day in non-leap year
+    '2024-04-30T23:59:59Z',      # April 30 -- 30-day month
+    '2024-06-30T23:59:59Z',      # June 30
+    '2024-09-30T23:59:59Z',      # September 30
+    '2024-11-30T23:59:59Z',      # November 30
+    '2024-01-01T00:00:00.000Z',  # midnight with fraction
+    '2024-12-31T23:59:59.999Z',  # last millisecond of year
+    '1926-01-01T00:00:00Z',      # parser min-year (if parser has year floor)
+    '2036-12-31T23:59:59Z',      # parser max-year (if parser has year ceiling)
+    '1970-01-01T00:00:00Z',      # Unix epoch -- universally significant boundary
+    '2038-01-19T03:14:07Z',      # Y2K38 -- 32-bit Unix timestamp overflow boundary
+])
+def test_iso_boundary_dates_true_positive(text):
+    """
+    Attack vector: ISO 8601 timestamps at valid calendar extremes.
+
+    Why a parser might fail: a parser that validates dates (rather than just
+    matching digit groups) may have off-by-one errors in month-day validation.
+    Leap day (Feb 29) is particularly sensitive because it requires knowing whether
+    the year is a leap year.
+
+    The 1926/2036 boundary tests are specific to this project: if the prose-year
+    extractor has a year-range guard [1926, 2036], these tests reveal whether that
+    same guard is applied consistently in the ISO extractor.
+
+    What failure reveals: the parser has unexpected gaps at valid calendar
+    boundaries, possibly due to restrictive range checks in the regex or
+    post-match validation logic.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+
+# ============================================================================
+# SECTION 7 -- FALSE POSITIVES: PARTIAL ISO STRINGS
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Incomplete ISO 8601 expressions -- missing required components.
+    '2024-03-15T',              # trailing T with no time component
+    'T09:04:08Z',               # time-only with no date portion
+    'T12:30:45',                # time-only, no date, no timezone
+    '2024-03',                  # year-month only (no day, no T)
+    'T',                        # bare T
+    '2024T',                    # year followed by bare T
+    '20240315',                 # compact ISO date (no T, no time)
+    '090408Z',                  # time-only, no date
+    '2024-W12-3',               # ISO week date (no T separator, not a datetime)
+    '2024-075T',                # ordinal date with trailing T but no time
+    '2024-01-01+00:00',         # date with offset but no T or time
+    '2024-13-15T',              # invalid month + trailing T only
+    'YYYY-MM-DDTHH:MM:SSZ',     # literal format string (not a real timestamp)
+    '--01-01T',                 # ISO 8601 specific date without year
+    '---01T',                   # ISO 8601 specific day without year/month
+])
+def test_iso_partial_false_positive(text):
+    """
+    Attack vector: partial or malformed ISO 8601 strings that are missing key components.
+
+    Why a parser might fail: a greedy regex that matches ``\d{4}-\d{2}-\d{2}``
+    will incorrectly match '2024-03-15' even when there is no time component,
+    classifying a bare date as an ISO datetime. Similarly, a regex that
+    matches ``T\d{2}:\d{2}:\d{2}`` without requiring a preceding date will
+    accept time-only strings.
+
+    The format string 'YYYY-MM-DDTHH:MM:SSZ' (commonly found in documentation,
+    README files, and API specs) is a textbook false positive: it contains all the
+    structural characters of an ISO timestamp but represents a format descriptor,
+    not a real date.
+
+    What failure reveals (false positive produced): the parser is over-matching,
+    treating partial ISO fragments as full ISO datetimes.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ============================================================================
+# SECTION 8 -- FALSE POSITIVES: ISO 8601 DURATION STRINGS
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # ISO 8601 section 4.4 defines *duration* strings beginning with 'P'.
+    # These look like they contain date components but represent interval lengths.
+    'PT1H30M',
+    'P1Y2M3DT4H5M6S',
+    'P30D',
+    'PT15M',
+    'PT0S',
+    'P1Y',
+    'P6M',
+    'P1Y6M',
+    'PT24H',
+    'PT1H',
+    'PT30M',
+    'PT45S',
+    'P2Y3M4DT5H6M7S',
+    'P0Y0M0DT0H0M0S',
+    'P1DT12H',
+    'P7D',
+    'P52W',                     # ISO 8601 week duration
+    'P1Y2M',
+    'PT0.5S',                   # fractional seconds in duration
+    'PT1H30M0S',
+    'P3Y6M4DT12H30M5S',
+    'P23DT23H',
+    'P4DT12H30M5S',
+    'P1M',
+    'P1W2D',
+    'P0D',
+    'PT0H',
+    'P1Y0M0DT0H0M0S',
+    'P10Y',
+    'PT168H',
+])
+def test_iso_duration_false_positive(text):
+    """
+    Attack vector: ISO 8601 duration (period) strings.
+
+    Why a parser might fail: duration strings contain the same letters used in
+    datetime strings (T for time separator, H for hour, M for minute/month,
+    D for day, S for second, Y for year) but in a completely different positional
+    grammar. A parser that looks for an isolated 'T' followed by digit groups
+    may accidentally fire on the interior of a duration string like
+    ``P1Y2M3DT4H5M6S``.
+
+    Duration strings are ubiquitous: FHIR resources use them for medication dosage
+    intervals, iCalendar (RFC 5545) uses them for event durations, and REST API
+    timeout parameters use them in configuration files.
+
+    What failure reveals (false positive produced): the parser cannot distinguish
+    ISO 8601 durations from ISO 8601 datetimes.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ============================================================================
+# SECTION 9 -- FALSE POSITIVES: LOOKS-LIKE-ISO (version strings, ticket IDs)
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Strings containing 'T' and digit groups that resemble ISO 8601 but are not.
+    'Project T-2024',
+    'v2024-03T1',
+    'ticket-2024-01T',
+    'model-T2024',
+    'T-bone steak from 2024',
+    'TICKET-2024-001',
+    'BUILD-2024-03-T7',
+    'API-v2-T2024',
+    'spec-2024T',
+    'config.T2024-01',
+    'SKU-2024-T1-001',
+    'RFC-2024T',
+    'T:2024',
+    'ref:2024-03-T',
+    '2024T-specification',
+    'v1.2024-T3',
+    'changelog-2024-T1',
+    'T2024.Q1',
+    'item-T-2024-A',
+    '2024-revision-T1',
+    'feature-T2024-01-alpha',
+    'MODEL-T-2024-EDITION',
+    'T+2024',
+    'prefix-T-suffix',
+    '2024-T-series',
+])
+def test_iso_looks_like_false_positive(text):
+    """
+    Attack vector: strings containing 'T' and digit groups that resemble ISO 8601
+    but are identifiers, version strings, or ticket references.
+
+    Why a parser might fail: a regex that matches ``\d{4}.*T.*\d{2}`` as a
+    heuristic will fire on product codes, ticket identifiers, and version strings
+    that happen to contain the letter T adjacent to a 4-digit year.
+
+    What failure reveals (false positive produced): the parser is tagging
+    non-temporal identifiers as dates.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ============================================================================
+# SECTION 10 -- FALSE POSITIVES: ISO INTERVAL (slash-separated, date-only)
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # ISO 8601 section 4.4.4 time intervals using slash -- date-only forms.
+    '2024-01-01/2024-03-31',
+    '2023-01-01/2023-12-31',
+    '2020-01-01/P1Y',
+    'P1Y/2021-01-01',
+    '2024-06-01/2024-06-30',
+    '2024-01/2024-06',
+    '2024-001/2024-366',
+    '2024-W01/2024-W52',
+])
+def test_iso_interval_false_positive(text):
+    """
+    Attack vector: ISO 8601 time interval strings using slash notation (date-only form).
+
+    Why a parser might fail: the left-hand side of an interval string like
+    ``2024-01-01/2024-03-31`` begins with a valid ISO date. A parser that searches
+    for ISO dates anywhere in the text will match the left side. The test asserts
+    that bare date-only intervals (no T separator, no time component) should not
+    trigger the ISO 8601 *datetime* handler.
+
+    What failure reveals (false positive produced): the parser is matching bare
+    YYYY-MM-DD date strings as ISO datetimes.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ============================================================================
+# SECTION 11 -- BOUNDARY: INVALID FIELD VALUES
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Syntactically ISO-like but contain out-of-range field values.
+    # No directional assertion -- recording behaviour for documentation.
+    '2024-13-01T00:00:00Z',          # month 13 (invalid)
+    '2024-00-01T00:00:00Z',          # month 0 (invalid)
+    '2024-01-00T00:00:00Z',          # day 0 (invalid)
+    '2024-01-32T00:00:00Z',          # day 32 (invalid in all months)
+    '2024-02-30T00:00:00Z',          # Feb 30 (invalid)
+    '2023-02-29T00:00:00Z',          # Feb 29 in non-leap year (invalid)
+    '2024-01-01T24:00:00Z',          # hour 24 (permitted in ISO for end-of-day only)
+    '2024-01-01T25:00:00Z',          # hour 25 (always invalid)
+    '2024-01-01T00:60:00Z',          # minute 60 (invalid)
+    '2024-01-01T00:00:60Z',          # second 60 without leap-second context
+    '2024-06-30T23:59:60Z',          # leap second (valid in UTC but rarely supported)
+    '2024-01-01T00:00:61Z',          # second 61 (always invalid)
+    '9999-12-31T23:59:59Z',          # far-future date (beyond typical range)
+    '0000-01-01T00:00:00Z',          # year 0 (proleptic Gregorian calendar)
+    '2024-01-01T00:00:00+25:00',     # offset > 14 hours (invalid per RFC 3339)
+    '2024-01-01T00:00:00-13:00',     # offset < -12 hours (invalid per RFC 3339)
+    '2024-04-31T00:00:00Z',          # April has only 30 days
+    '2024-06-31T00:00:00Z',          # June has only 30 days
+    '2024-09-31T00:00:00Z',          # September has only 30 days
+    '2024-11-31T00:00:00Z',          # November has only 30 days
+])
+def test_iso_invalid_field_values_boundary(text):
+    """
+    Attack vector: syntactically ISO-like strings with out-of-range field values.
+
+    Why a parser might fail to reject: a pure regex approach that does not validate
+    calendar or time arithmetic will match any string that fits the digit-group
+    pattern, regardless of whether month 13, day 0, or hour 25 are semantically
+    valid. This is sometimes called 'structural matching without semantic validation'.
+
+    The leap-second case (23:59:60) is especially nuanced: it is defined in the UTC
+    standard for days on which IERS inserts a leap second, but most software
+    (including Python's datetime module) does not support it.
+
+    This test does not assert a direction -- it records whatever the parser does
+    so that the development team can make an explicit decision about tolerance policy.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert isinstance(result, dict)
+
+
+# ============================================================================
+# SECTION 12 -- UNICODE HOMOGLYPH ATTACKS
+# ============================================================================
+
+@pytest.mark.parametrize('text, description', [
+    # Fullwidth Latin letter T (U+FF34) -- looks like ASCII T but byte-distinct.
+    ('2024-01-01Ｔ00:00:00Z', 'fullwidth T capital (U+FF34) between date and time'),
+    ('2024-01-01ｔ00:00:00Z', 'fullwidth t lowercase (U+FF54) between date and time'),
+
+    # Fullwidth colon (U+FF1A).
+    ('2024-01-01T00：00：00Z', 'fullwidth colons in time component (U+FF1A)'),
+
+    # Fullwidth Z (U+FF3A) -- looks like 'Z' but not the ASCII UTC designator.
+    ('2024-01-01T00:00:00Ｚ', 'fullwidth Z (U+FF3A) as timezone designator'),
+
+    # Fullwidth digits (U+FF10-U+FF19).
+    ('２０２４-01-01T00:00:00Z', 'fullwidth digits in year (2024 fullwidth)'),
+    ('2024-０１-01T00:00:00Z', 'fullwidth digits in month'),
+    ('2024-01-０１T00:00:00Z', 'fullwidth digits in day'),
+
+    # Zero-width space (U+200B) -- breaks tokenisation invisibly.
+    ('2024-01-01​T00:00:00Z', 'zero-width space before T (U+200B)'),
+    ('2024-01-01T​00:00:00Z', 'zero-width space after T (U+200B)'),
+    ('2024-01-01T00:00:00​Z', 'zero-width space before Z (U+200B)'),
+
+    # Soft hyphen (U+00AD) in place of ASCII hyphen.
+    ('2024­01­01T00:00:00Z', 'soft hyphens in date separators (U+00AD)'),
+
+    # Arabic-Indic digits (U+0660-U+0669).
+    ('٢٠٢٤-01-01T00:00:00Z', 'Arabic-Indic digits in year'),
+
+    # Minus sign (U+2212) in place of hyphen-minus (U+002D).
+    ('2024−01−01T00:00:00Z', 'minus sign (U+2212) in date separators'),
+
+    # RTL override character (U+202E).
+    ('2024-01-01T‮00:00:00Z', 'RTL override character (U+202E) inside timestamp'),
+
+    # En-dash (U+2013) replacing hyphen-minus.
+    ('2024–01–01T00:00:00Z', 'en-dashes in date separators (U+2013)'),
+
+    # Non-breaking hyphen (U+2011).
+    ('2024‑01‑01T00:00:00Z', 'non-breaking hyphens in date separators (U+2011)'),
+])
+def test_iso_unicode_homoglyph(text, description):
+    """
+    Attack vector: ISO 8601 strings with Unicode homoglyphs replacing ASCII characters.
+
+    Why a parser might be fooled: visual similarity between Unicode characters and
+    their ASCII counterparts means that a human auditing a test input sees what
+    appears to be a valid ISO timestamp, but the byte sequence is different. A
+    parser that does not perform Unicode normalisation (NFC/NFKC) before regex
+    matching will treat these as non-matching inputs.
+
+    Conversely, a parser that uses Python's ``re.UNICODE`` flag (the default in
+    Python 3) may unintentionally match fullwidth digits via ``\d``, producing
+    an unexpected match where none was intended.
+
+    Security relevance: homoglyph attacks are used to bypass input validation in
+    security-sensitive contexts. A parser that accepts homoglyphs as valid dates
+    is potentially vulnerable to temporal data injection attacks.
+
+    This test records current behaviour without asserting direction.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert isinstance(result, dict)
+
+
+# ============================================================================
+# SECTION 13 -- ADDITIONAL TRUE POSITIVES (reaching 250+ total cases)
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Reduced-precision forms (hours + minutes, no seconds).
+    '2024-01-01T00:00Z',
+    '2024-06-15T12:30Z',
+    '2024-12-31T23:59Z',
+    '2017-02-03T09:04Z',         # motivating example without seconds
+    '2024-03-15T14:30+05:30',
+    '2024-07-04T17:00-05:00',
+    '2024-01-01T00:00+00:00',
+    '2024-08-15T08:00-07:00',
+    '2024-09-22T06:00+09:00',
+    '2026-06-15T12:30Z',
+    '2027-01-01T00:00Z',
+    '2028-02-29T12:00Z',
+    '2029-11-15T08:30Z',
+    '2030-12-31T23:59Z',
+    '2031-07-04T17:00Z',
+    '2033-12-25T00:00Z',
+    '2034-01-01T00:00Z',
+    '2035-06-30T23:59Z',
+    '2036-12-31T23:58Z',
+    # Hours-only precision.
+    '2024-01-01T00Z',
+    '2024-06-15T12Z',
+    '2024-12-31T23Z',
+    '2017-02-03T09Z',
+    # Multiple timestamps in one string.
+    'start 2024-01-01T00:00:00Z end 2024-12-31T23:59:59Z',
+    'range: 2024-03-01T08:00:00Z to 2024-03-31T17:00:00Z',
+    'from 2024-06-01T00:00:00Z through 2024-06-30T23:59:59Z',
+    # JSON-like context.
+    '{"timestamp": "2024-01-01T00:00:00Z"}',
+    '{"created_at": "2024-06-15T12:30:45.123Z", "id": 42}',
+    '{"start": "2024-01-01T00:00:00Z", "end": "2024-12-31T23:59:59Z"}',
+    # Surrounding punctuation.
+    '(2024-01-01T00:00:00Z)',
+    '[2024-06-15T12:30:45Z]',
+    '<2024-12-31T23:59:59Z>',
+    # Extended year range coverage.
+    '1930-06-15T12:00:00Z',
+    '1940-01-01T00:00:00Z',
+    '1950-12-31T23:59:59Z',
+    '1960-07-04T17:00:00Z',
+    '1975-11-28T08:00:00Z',
+    '1985-09-11T08:46:00Z',
+    '1995-04-10T21:00:00Z',
+    '2005-02-24T04:00:00Z',
+    '2015-03-11T05:46:23Z',
+    '2025-09-15T14:22:33Z',
+    '2026-08-01T12:00:00Z',
+    '2028-11-11T11:11:11Z',
+    # Assorted additional dates.
+    '2024-04-15T09:30:00Z',
+    '2024-05-20T15:00:00Z',
+    '2024-06-25T18:30:00Z',
+    '2024-07-10T06:00:00Z',
+    '2024-10-05T20:00:00+03:00',
+    '2024-11-11T11:11:11Z',
+    '2024-12-01T00:00:01Z',
+    '2025-01-31T23:00:00Z',
+    '2025-02-14T14:00:00Z',
+    '2025-03-21T09:00:00+00:00',
+    '2025-04-01T12:00:00Z',
+    '2025-05-05T05:05:05Z',
+    # Fractional seconds AND timezone offsets combined.
+    '2024-03-15T08:00:00.123+05:30',
+    '2024-07-04T17:00:00.500-07:00',
+    '2024-12-25T00:00:00.001+00:00',
+    '2025-01-01T00:00:00.000Z',
+    '2026-06-15T12:30:45.678+02:00',
+    # Additional Z variants.
+    '2024-02-15T10:00:00Z',
+    '2024-03-20T16:00:00Z',
+    '2024-04-25T22:00:00Z',
+    '2024-05-30T04:00:00Z',
+    '2024-06-05T08:00:00Z',
+    '2024-07-11T14:00:00Z',
+    '2024-08-16T20:00:00Z',
+    '2024-09-21T02:00:00Z',
+    '2024-10-26T18:00:00Z',
+    '2024-11-30T11:00:00Z',
+    '2024-12-15T07:00:00Z',
+    '2025-01-20T13:00:00Z',
+    '2025-02-25T19:00:00Z',
+    '2025-03-30T01:00:00Z',
+    '2025-04-04T05:00:00Z',
+    '2025-05-09T09:00:00Z',
+    '2025-06-14T15:00:00Z',
+    '2025-07-19T21:00:00Z',
+    '2025-08-24T03:00:00Z',
+    '2025-09-28T17:00:00Z',
+])
+def test_iso_additional_true_positive(text):
+    """
+    Attack vector: additional ISO 8601 variants covering reduced-precision forms,
+    multi-timestamp strings, JSON-embedded contexts, and extended year ranges.
+
+    Why a parser might fail: reduced-precision forms (hours-only, hours+minutes
+    without seconds) are valid under ISO 8601 section 4.2.2.3 but are rarely
+    included in regex patterns built to match the canonical 6-component form
+    (HH:MM:SS). JSON embedding tests whether the parser handles quoted strings
+    correctly. Multi-timestamp strings test whether the parser returns multiple
+    matches rather than stopping after the first.
+
+    The extended year coverage (1930s through 2036) ensures that the parser's
+    year-range filter (if any) correctly includes the full expected range without
+    off-by-one errors at either boundary.
+
+    What failure reveals: each parametrised failure locates a specific coverage
+    gap -- whether in precision handling, JSON context, multi-match behaviour, or
+    year-range filtering.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0

--- a/tests/red_team/test_rt_last_next.py
+++ b/tests/red_team/test_rt_last_next.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+"""
+Red Team: Last/Next Patterns (last week, next month, last 10 days, next couple of weeks)
+Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+"""
+import pytest
+from fast_parse_time.api import extract_relative_times
+pytestmark = pytest.mark.xfail(reason='red_team: not yet validated')
+
+_FRAMES_S = ['second','minute','hour','day','week','month','year','decade']
+_FRAMES_P = ['seconds','minutes','hours','days','weeks','months','years','decades']
+
+# ── TRUE POSITIVES: last + singular frame ────────────────────────────────────
+_TP_LAST_SINGULAR = [f'last {f}' for f in _FRAMES_S]
+
+@pytest.mark.parametrize('text', _TP_LAST_SINGULAR)
+def test_tp_last_singular_frames(text):
+    """'last FRAME' for all 8 singular time frames. Failure: frame not in last-pattern lexicon."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: next + singular frame ────────────────────────────────────
+_TP_NEXT_SINGULAR = [f'next {f}' for f in _FRAMES_S]
+
+@pytest.mark.parametrize('text', _TP_NEXT_SINGULAR)
+def test_tp_next_singular_frames(text):
+    """'next FRAME' for all 8 singular time frames. Failure: frame not in next-pattern lexicon."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: last + numeric + frame ───────────────────────────────────
+_TP_LAST_NUMERIC = (
+    [f'last 1 {f}' for f in _FRAMES_P] +
+    [f'last 5 {f}' for f in _FRAMES_P] +
+    [f'last 10 {f}' for f in _FRAMES_P] +
+    [f'last 30 {f}' for f in _FRAMES_P] +
+    [f'last 90 {f}' for f in _FRAMES_P] +
+    [f'last 100 {f}' for f in _FRAMES_P] +
+    [f'last 365 {f}' for f in _FRAMES_P] +
+    [f'last 1000 {f}' for f in _FRAMES_P]
+)
+
+@pytest.mark.parametrize('text', _TP_LAST_NUMERIC)
+def test_tp_last_numeric_frames(text):
+    """'last N FRAME' for all 8 frames and multiple cardinalities.
+    Failure: numeric cardinality not supported in last-pattern."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: next + numeric + frame ───────────────────────────────────
+_TP_NEXT_NUMERIC = (
+    [f'next 1 {f}' for f in _FRAMES_P] +
+    [f'next 5 {f}' for f in _FRAMES_P] +
+    [f'next 10 {f}' for f in _FRAMES_P] +
+    [f'next 30 {f}' for f in _FRAMES_P] +
+    [f'next 90 {f}' for f in _FRAMES_P] +
+    [f'next 100 {f}' for f in _FRAMES_P]
+)
+
+@pytest.mark.parametrize('text', _TP_NEXT_NUMERIC)
+def test_tp_next_numeric_frames(text):
+    """'next N FRAME' for all 8 frames and multiple cardinalities.
+    Failure: numeric cardinality not supported in next-pattern."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: quantifier forms ─────────────────────────────────────────
+_TP_QUANT = [
+    'last couple of days','last couple of weeks','last couple of months','last couple of years',
+    'last few days','last few weeks','last few months','last few years',
+    'next couple of days','next couple of weeks','next couple of months','next couple of years',
+    'next few days','next few weeks','next few months','next few years',
+]
+
+@pytest.mark.parametrize('text', _TP_QUANT)
+def test_tp_last_next_quantifier(text):
+    """'last/next couple of/few FRAME' quantifier forms.
+    Failure: quantifier forms not supported in last/next patterns."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: sentence embedded ────────────────────────────────────────
+_TP_EMBEDDED = [
+    'show me data from last week','what happened last month',
+    'the next quarter starts soon','next year we will revisit',
+    'last 30 days performance report','next 90 days roadmap',
+    'review the last 12 months','plan for next 6 months',
+]
+
+@pytest.mark.parametrize('text', _TP_EMBEDDED)
+def test_tp_sentence_embedded(text):
+    """Last/next embedded in natural sentences. Failure: prose context breaks extraction."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── FALSE POSITIVES: last as adjective/noun ──────────────────────────────────
+_FP_LAST_NOUN = [
+    'the last chapter','last name','last call','last resort','last rites',
+    'at last','the very last','breathing his last','the last of the mohicans',
+    'last but not least','saving the best for last','last in first out',
+    'his last words','she came in last','that is the last straw',
+]
+
+@pytest.mark.parametrize('text', _FP_LAST_NOUN)
+def test_fp_last_as_adjective_or_noun(text):
+    """'last' used as adjective or noun without a following time unit.
+    Failure: 'last' matched as temporal without a time unit anchor."""
+    assert len(extract_relative_times(text)) == 0
+
+# ── FALSE POSITIVES: next as adjective/noun ──────────────────────────────────
+_FP_NEXT_NOUN = [
+    'next please','next door','next in line','what comes next',
+    'next of kin','the next big thing','next to nothing','up next',
+    'next on the agenda','who is next','take it to the next level',
+    'next steps','you are next','the sequel comes next',
+]
+
+@pytest.mark.parametrize('text', _FP_NEXT_NOUN)
+def test_fp_next_as_adjective_or_noun(text):
+    """'next' used without following time unit. Failure: 'next' alone matched as temporal."""
+    assert len(extract_relative_times(text)) == 0
+
+# ── FALSE POSITIVES: last seen/modified ──────────────────────────────────────
+_FP_LAST_VERB = [
+    'last seen online','last modified','last updated','last accessed',
+    'last changed','last run','last deployed','last audited',
+]
+
+@pytest.mark.parametrize('text', _FP_LAST_VERB)
+def test_fp_last_verb_phrases(text):
+    """'last VERB' phrases where the following word is a participle not a time unit.
+    Failure: 'last' + non-time-unit verb matched as temporal."""
+    assert len(extract_relative_times(text)) == 0
+
+# ── BOUNDARY ──────────────────────────────────────────────────────────────────
+def test_boundary_last_zero_days():
+    """last 0 days — degenerate cardinality. xfail."""
+    extract_relative_times('last 0 days')  # should not raise
+
+def test_boundary_last_negative():
+    """last -5 days — nonsensical. Should not match."""
+    assert len(extract_relative_times('last -5 days')) == 0
+
+def test_boundary_very_large():
+    """last 999999 years — extreme cardinality."""
+    assert len(extract_relative_times('last 999999 years')) > 0

--- a/tests/red_team/test_rt_numeric_delimited.py
+++ b/tests/red_team/test_rt_numeric_delimited.py
@@ -1,0 +1,809 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+"""
+Red Team: Numeric-Delimited Date Patterns
+==========================================
+This module adversarially probes the fast-parse-time parser handling of
+numeric date strings that use the three canonical delimiters: slash (/),
+hyphen (-), and dot (.). These formats are ubiquitous in computing contexts
+and represent one of the highest-density ambiguity zones in temporal NLP.
+
+The core challenge is that character sequences composing valid dates --
+two or four digit numeric tokens separated by a single punctuation character --
+are structurally identical to IP addresses (192.168.1.1), version strings
+(1.2.3), file paths (foo/bar/baz), phone/ISBN numbers (0-306-40615-2), and
+many other domain-specific encodings. A naive lexical parser that matches
+on shape alone will produce an unacceptable false-positive rate across these
+categories. This file tests the boundaries of parser discrimination.
+
+Attack surface taxonomy:
+  A. Delimiter-variant true positives (/, -, .)
+  B. IP address false positives (dot-notation quad octets)
+  C. Semantic version false positives (SemVer: MAJOR.MINOR.PATCH)
+  D. File path false positives (slash-delimited non-date path segments)
+  E. Phone/ISBN false positives (hyphen-delimited numeric identifiers)
+  F. Year boundary edge cases (parser range clipping behavior)
+  G. Calendar logic edge cases (day 0, month 0, Feb 29 leap/non-leap)
+  H. Unicode homoglyph and script substitution attacks
+
+Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+"""
+
+import pytest
+from fast_parse_time import extract_explicit_dates
+
+# Every test in this module is provisional. Failures indicate either a gap in
+# parser coverage (for true-positive sections) or a false-positive leak (for
+# false-positive sections). All cases require triage before being promoted to
+# the main test suite.
+pytestmark = pytest.mark.xfail(reason='red_team: not yet validated')
+
+
+# ===========================================================================
+# SECTION 1 -- TRUE POSITIVES: SLASH-DELIMITED DATES (MM/DD/YYYY)
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Standard slash-delimited full dates embedded in sentence context.
+    # These represent the canonical North American date format and should
+    # reliably trigger FULL_EXPLICIT_DATE recognition. The surrounding
+    # sentence context exercises the parser boundary detection logic,
+    # ensuring that whitespace tokenization does not discard the match.
+    'The meeting is on 04/08/2024.',
+    'Please review the report dated 01/15/2023.',
+    'Contract signed 12/31/2022 is attached.',
+    'Invoice due 07/04/2021 has been paid.',
+    'The event was held on 11/11/2011.',
+    'We need it done by 03/03/2033.',
+    'Submission deadline: 09/09/2029.',
+    'Last updated 06/15/2025.',
+    'Born on 05/20/1985.',
+    'Expires 08/01/2030.',
+    # Leading zero variants -- tests whether the parser handles zero-padded
+    # month and day fields identically to non-padded variants.
+    'Dated 01/01/2024.',
+    'Dated 02/05/2024.',
+    'Dated 03/09/2024.',
+    'Dated 04/08/2024.',
+    'Dated 05/07/2024.',
+    'Dated 06/06/2024.',
+    'Dated 07/05/2024.',
+    'Dated 08/04/2024.',
+    'Dated 09/03/2024.',
+    'Dated 10/02/2024.',
+    'Dated 11/01/2024.',
+    'Dated 12/31/2024.',
+    # Non-zero-padded variant -- same dates without leading zeros.
+    # A robust parser must handle both 04/08/2024 and 4/8/2024 identically.
+    'Dated 1/1/2024.',
+    'Dated 2/5/2024.',
+    'Dated 3/9/2024.',
+    'Dated 4/8/2024.',
+    'Dated 5/7/2024.',
+    'Dated 6/6/2024.',
+    'Dated 7/5/2024.',
+    'Dated 8/4/2024.',
+    'Dated 9/3/2024.',
+    'Dated 10/2/2024.',
+    'Dated 11/1/2024.',
+    'Dated 12/31/2024.',
+    # Padded whitespace
+    '   04/08/2024   ',
+    '  01/01/2026  ',
+    # Boundary years (min=1926, max=2036)
+    'Born 01/01/1926.',
+    'Expires 12/31/2036.',
+    # All months at valid day ranges
+    'January: 01/15/2024.',
+    'February: 02/15/2024.',
+    'March: 03/15/2024.',
+    'April: 04/15/2024.',
+    'May: 05/15/2024.',
+    'June: 06/15/2024.',
+    'July: 07/15/2024.',
+    'August: 08/15/2024.',
+    'September: 09/15/2024.',
+    'October: 10/15/2024.',
+    'November: 11/15/2024.',
+    'December: 12/15/2024.',
+    # Additional padded and contextual variants
+    'Report finalized on 04/08/2024 and sent.',
+    'Event scheduled for 04/08/2024 at noon.',
+    'Confirm by 04/08/2024 or earlier.',
+    'Signed off 04/08/2024 by the team.',
+    'The deadline was 12/31/2024.',
+    'Review period: 01/01/2024 to 12/31/2024.',
+    'Filed 06/15/1980.',
+    'Closed 06/15/2000.',
+    'Opened 06/15/2024.',
+])
+def test_true_positive_slash_delimited(text):
+    """
+    True positive: slash-delimited MM/DD/YYYY dates should be detected.
+
+    Attack vector: Standard North American numeric date format using the
+    forward-slash delimiter. This is the highest-frequency date format in
+    English-language business and legal documents.
+
+    Why a parser might fail: Overly restrictive word-boundary anchoring may
+    require surrounding whitespace or punctuation patterns that do not always
+    hold. Additionally, parsers that strip leading zeros before matching may
+    fail on the un-padded variants (4/8/2024 vs 04/08/2024).
+
+    Failure reveals: Core numeric date extraction is not firing on a canonical
+    format that must be a first-order priority for any date parser.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ===========================================================================
+# SECTION 2 -- TRUE POSITIVES: HYPHEN-DELIMITED DATES (MM-DD-YYYY)
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    'Report dated 04-08-2024.',
+    'Invoice 06-05-2016 submitted.',
+    'Deadline 12-31-2023.',
+    'Event on 01-01-2027.',
+    'Filed 03-15-2024.',
+    'Closed 07-04-2021.',
+    'Opened 09-09-2019.',
+    'Scheduled for 11-11-2025.',
+    'Last seen 05-20-1985.',
+    'Renewed 08-01-2030.',
+    'Date: 01-01-2024.',
+    'Date: 02-05-2024.',
+    'Date: 03-09-2024.',
+    'Date: 10-02-2024.',
+    'Date: 11-01-2024.',
+    'Date: 12-31-2024.',
+    'Date: 1-1-2024.',
+    'Date: 3-9-2024.',
+    'Date: 6-6-2024.',
+    'Date: 9-3-2024.',
+    'Date: 11-1-2024.',
+    'Date: 12-31-2024.',
+    'Record from 01-01-1926.',
+    'Expiry on 12-31-2036.',
+    '01-15-2024 was a Monday.',
+    '02-15-2024 was a Thursday.',
+    '03-15-2024 was a Friday.',
+    '04-15-2024 was a Monday.',
+    '05-15-2024 was a Wednesday.',
+    '06-15-2024 was a Saturday.',
+    '07-15-2024 was a Monday.',
+    '08-15-2024 was a Thursday.',
+    '09-15-2024 was a Sunday.',
+    '10-15-2024 was a Tuesday.',
+    '11-15-2024 was a Friday.',
+    '12-15-2024 was a Sunday.',
+    'The report for 04-08-2024 is ready.',
+    'As of 06-05-2016 the contract is active.',
+    'Effective 01-01-2027 new rules apply.',
+    'Invoice generated 12-31-2023 is overdue.',
+    'Log entry from 03-15-2024 flagged.',
+])
+def test_true_positive_hyphen_delimited(text):
+    """
+    True positive: hyphen-delimited MM-DD-YYYY dates should be detected.
+
+    Attack vector: Hyphen-delimited numeric date format. The hyphen presents
+    the highest disambiguation challenge because it is also used to join
+    month abbreviations to year tokens (Oct-23), to form ISO 8601 dates
+    (2024-04-08), and to construct compound identifiers throughout computing
+    contexts (version strings, phone numbers, ISBN, product codes).
+
+    Why a parser might fail: A parser relying on the same hyphen-pattern
+    recognition for both MONTH-YEAR and DAY-MONTH-YEAR may have ordering or
+    priority conflicts that cause full date suppression.
+
+    Failure reveals: The hyphen extractor priority or conflict resolution
+    logic is incorrectly discarding full MM-DD-YYYY matches in favor of
+    partial sub-patterns.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ===========================================================================
+# SECTION 3 -- TRUE POSITIVES: DOT-DELIMITED DATES (MM.DD.YYYY)
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    'Completed 04.08.2024.',
+    'Deadline 12.31.2023.',
+    'Filed on 01.15.2023.',
+    'Submitted 07.04.2021.',
+    'Renewed 08.01.2030.',
+    'Issued 06.15.2025.',
+    'Effective 03.01.2027.',
+    'Cancelled 09.09.2029.',
+    'Received 11.11.2011.',
+    'Shipped 05.20.1985.',
+    'Date: 01.01.2024.',
+    'Date: 02.05.2024.',
+    'Date: 03.09.2024.',
+    'Date: 10.02.2024.',
+    'Date: 11.01.2024.',
+    'Date: 12.31.2024.',
+    'Date: 1.1.2024.',
+    'Date: 3.9.2024.',
+    'Date: 6.6.2024.',
+    'Date: 9.3.2024.',
+    'Date: 12.31.2024.',
+    'Born 01.01.1926.',
+    'Expiry 12.31.2036.',
+    '01.15.2024 -- January date.',
+    '02.15.2024 -- February date.',
+    '03.15.2024 -- March date.',
+    '04.15.2024 -- April date.',
+    '05.15.2024 -- May date.',
+    '06.15.2024 -- June date.',
+    '07.15.2024 -- July date.',
+    '08.15.2024 -- August date.',
+    '09.15.2024 -- September date.',
+    '10.15.2024 -- October date.',
+    '11.15.2024 -- November date.',
+    '12.15.2024 -- December date.',
+    'Completed on 04.08.2024 as required.',
+    'Submission for 12.31.2023 reviewed.',
+    'Entered into system 01.15.2023.',
+    'Transaction 07.04.2021 processed.',
+    'Renewal due 08.01.2030 confirmed.',
+])
+def test_true_positive_dot_delimited(text):
+    """
+    True positive: dot-delimited MM.DD.YYYY dates should be detected.
+
+    Attack vector: Period/dot as date delimiter. This is the format most
+    prone to confounding with IP addresses and semantic version strings
+    because all three use the ASCII period (U+002E) as their separator.
+
+    Why a parser might fail: If IP-address and version-string suppression
+    rules are implemented as prefix guards (i.e., if the string looks like
+    an IP, reject it), there is a risk of over-broad suppression that also
+    eliminates valid dates where the first two components happen to fall in
+    octet-range (e.g., 12.31 could be naively read as a partial IP).
+
+    Failure reveals: The IP-guard heuristic is either too broad or incorrectly
+    anchored, causing valid dates to be rejected at the pre-filter stage.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ===========================================================================
+# SECTION 4 -- FALSE POSITIVES: IP ADDRESSES
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # IPv4 addresses are structurally dot.digit.digit.digit, the same surface
+    # form as a date when the parser performs only character-class matching
+    # without calendar-logic validation. A production parser MUST reject these.
+    #
+    # Key discriminator: IP addresses have four numeric components; dates have
+    # three. Additionally, IP octets range 0-255 while date fields have tighter
+    # bounds (month 1-12, day 1-31).
+    'Server address is 192.168.1.1.',
+    'Connect to 10.0.0.255 for internal access.',
+    'The gateway is at 172.16.254.1.',
+    'DNS server: 8.8.8.8.',
+    'Localhost is 127.0.0.1.',
+    'Null route: 0.0.0.0.',
+    'Broadcast: 255.255.255.255.',
+    'Private network: 10.10.10.10.',
+    'Host at 192.0.2.1.',
+    'Reserved: 169.254.1.1.',
+    'Multicast: 224.0.0.1.',
+    'Loopback alt: 127.0.0.2.',
+    'APIPA: 169.254.0.1.',
+    'Class A: 10.20.30.40.',
+    'Class B: 172.31.0.1.',
+    'Class C: 192.168.100.200.',
+    'Connect to host 10.0.1.100 now.',
+    'Primary DNS 8.8.8.8, secondary 8.8.4.4.',
+    'Failed to reach 192.168.0.254.',
+    'Internal: 10.100.200.1.',
+    'External: 203.0.113.1.',
+    'The server at 198.51.100.42 is down.',
+    'Check 172.20.10.1 for the proxy.',
+    'IANA reserved 100.64.0.1.',
+    'IPv4 mapped: 0.0.0.128.',
+    'IP 192.168.1.1 is unreachable',
+    'Ping 10.0.0.1 failed',
+    'Route via 172.16.0.1 expired',
+    'Firewall rule for 10.0.0.0.',
+    'Subnet mask 255.255.0.0.',
+    'Configured 192.168.10.254.',
+    'Test host 172.17.0.1.',
+    'Local network 10.1.2.3.',
+    'BGP peer 1.2.3.4.',
+    'Blacklisted: 203.0.113.99.',
+    'NAT source: 10.50.100.1.',
+    'Traceroute via 8.8.4.4.',
+    'VPN endpoint 172.18.0.1.',
+    'The device at 192.168.2.100 is offline.',
+    'Scanning 10.0.1.0/24 for hosts.',
+    'Default gateway: 192.168.1.254.',
+])
+def test_false_positive_ip_addresses(text):
+    """
+    False positive guard: IP addresses must not be classified as dates.
+
+    Attack vector: IPv4 dot-quad notation (A.B.C.D) is structurally similar
+    to dot-delimited date strings (MM.DD.YYYY). A parser that tokenizes on
+    periods and checks for numeric fields will encounter both formats and must
+    apply discriminating logic to separate them.
+
+    Discrimination strategy the parser should implement:
+      1. Component count: IP addresses have 4 components; dates have 3.
+      2. Year anchor: the last component of a date must be a 4-digit number
+         in a valid year range; IP octets are always <= 3 digits.
+      3. Octet-range suppression: if ALL components are in range [0, 255]
+         and there are exactly 4 components, treat as IP.
+
+    Why a parser might fail: Regex-first parsers that match on a greedy
+    sub-sequence might match a 3-component sub-sequence of an IP address.
+
+    Failure reveals: The parser is matching on structural shape alone without
+    calendar-logic validation, producing systematic false positives on network
+    configuration content.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ===========================================================================
+# SECTION 5 -- FALSE POSITIVES: SEMANTIC VERSION STRINGS
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # SemVer strings (MAJOR.MINOR.PATCH) share the three-component dot-delimited
+    # structure with dot-delimited dates. For version strings where all three
+    # components fall within calendar-valid ranges, purely lexical or range-based
+    # disambiguation will fail.
+    'Software version 1.2.3 is installed.',
+    'Upgrade to 2.0.1 immediately.',
+    'Running kernel 10.0.4.',
+    'Library version 3.14.159.',
+    'Release 1.0.0 is now live.',
+    'Patch version 12.0.1 fixes the bug.',
+    'Version 4.2.0 introduces new features.',
+    'Downgrade to 0.9.1 if needed.',
+    'API at version 5.3.2.',
+    'Build 7.1.0 passed all checks.',
+    'Current: v1.2.3.',
+    'Latest: v2.0.1.',
+    'Tagged v10.0.4 in git.',
+    'SemVer 3.14.159.',
+    'Frozen at 1.0.0-rc1.',
+    'Beta: 2.1.0-beta.',
+    'Alpha: 0.0.1-alpha.',
+    'The package is at 6.5.4.',
+    'Requires >=1.2.3.',
+    'Compatible with 3.0.0.',
+    'Breaking change in 2.0.0.',
+    'Pinned to 4.1.2.',
+    'Updated dependency from 1.0.0 to 1.1.0.',
+    'Node version 18.0.0.',
+    'Python 3.11.0 released.',
+    'npm 9.0.0 ships with node 18.',
+    'pip 23.0.1 available.',
+    'gcc 12.3.0 compiler.',
+    'clang 16.0.4 installed.',
+    'openssl 3.0.9 patched.',
+    'Django 4.2.0 is the LTS release.',
+    'Flask 3.0.0 dropped Python 2.',
+    'React 18.0.0 released with concurrent mode.',
+    'Vue 3.3.0 ships composition API improvements.',
+    'TensorFlow 2.0.0 broke backward compat.',
+    'PyTorch 1.13.0 has new features.',
+    'numpy 1.24.0 deprecates several APIs.',
+    'scipy 1.10.0 adds new solvers.',
+    'pandas 2.0.0 changes the index.',
+    'matplotlib 3.7.0 released.',
+])
+def test_false_positive_version_strings(text):
+    """
+    False positive guard: semantic version strings must not be classified as dates.
+
+    Attack vector: Semantic version numbers (SemVer: MAJOR.MINOR.PATCH) are
+    three-component dot-delimited numeric sequences -- structurally identical
+    to dot-delimited date strings. For version strings where all three
+    components fall within calendar-valid ranges, purely lexical or range-based
+    disambiguation will fail.
+
+    Why a parser might fail: A parser that only validates component ranges
+    (month 1-12, day 1-31) will still fire on '1.2.3' because all values are
+    in range. Only the absence of a four-digit year component or the presence
+    of contextual cues (the word 'version', 'v' prefix) can reliably
+    disambiguate.
+
+    Failure reveals: The parser lacks four-digit year enforcement and/or
+    contextual suppression for software version notation.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ===========================================================================
+# SECTION 6 -- FALSE POSITIVES: FILE PATHS
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Slash-delimited file paths can contain numeric directory components
+    # that superficially resemble date fragments.
+    'See path/to/file/2024 for details.',
+    'Stored in 12/something/else.',
+    'Navigate to foo/bar/baz.',
+    'Check /var/log/app/error.txt.',
+    'Located at /home/user/documents/report.',
+    'Path: /usr/local/share/2024.',
+    'Backup in /data/backups/archive.',
+    'Logs at /var/log/2024/01/.',
+    'Source: /opt/myapp/config/settings.',
+    'Artifact: build/outputs/release.',
+    'File at 99/foo/bar.',
+    'Dir: a1/b2/c3.',
+    'Relative: ./src/main/java.',
+    'URL path: /api/v1/users.',
+    'Route: /orders/2024/list.',
+    'Endpoint: /v2/reports/summary.',
+    'Resource: /assets/images/logo.png.',
+    'CDN: /static/js/bundle.min.js.',
+    'Archive: /backup/2024/01/dump.sql.',
+    'Config at /etc/myapp/settings.conf.',
+    'Log entry in /var/log/syslog.',
+    'Data at /mnt/data/raw/input.',
+    'Output to /tmp/results/run.',
+    'Import from /imports/batch/file.csv.',
+    'Cache at /cache/v1/index.',
+])
+def test_false_positive_file_paths(text):
+    """
+    False positive guard: slash-delimited file paths must not trigger date extraction.
+
+    Attack vector: File and URL paths use the forward slash as a structural
+    delimiter, the same character used in MM/DD/YYYY date notation. Paths
+    containing numeric directory names (e.g., /var/log/2024/01/) can look
+    superficially similar to partial date strings.
+
+    Why a parser might fail: A path-unaware parser that searches for
+    slash-delimited numeric sequences will encounter path components and
+    attempt to interpret them as date fields. If the parser does not validate
+    that the matched sequence is surrounded by word boundaries appropriate for
+    dates (not preceded by alphanumeric path context), false positives occur.
+
+    Failure reveals: The parser boundary anchoring or context-awareness is
+    insufficient to suppress matches within file path token sequences.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ===========================================================================
+# SECTION 7 -- FALSE POSITIVES: PHONE / ISBN / HYPHEN IDENTIFIERS
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Hyphen-delimited numeric identifiers (ISBN, phone numbers, product codes)
+    # share the structural shape of hyphen-delimited dates.
+    'ISBN: 0-306-40615-2.',
+    'ISBN-13: 978-3-16-148410-0.',
+    'ISBN: 978-0-306-40615-7.',
+    'Call us at 555-867-5309.',
+    'Toll free: 800-555-0199.',
+    'Fax: 212-555-0100.',
+    'International: +1-800-555-0199.',
+    'Product code: A1-2023-XYZ.',
+    'Serial: 1234-5678-9012.',
+    'License: ABCD-1234-EFGH-5678.',
+    'Order: ORD-2024-001.',
+    'Ticket: TKT-001-2025.',
+    'Reference: REF-12345-67890.',
+    'Case: CASE-2024-001.',
+    'Part number: PN-01-2345.',
+    'Barcode: 123-45-6789.',
+    'SKU: SKU-001-2024-A.',
+    'UPC: 01234-56789.',
+    'EAN: 4-012345-678901.',
+    'ISSN: 0378-5955.',
+    'Social security: 123-45-6789.',
+    'Driver license: D1234-56789-0.',
+    'Employee ID: EMP-001-2024.',
+    'Contract ref: CR-2024-00042.',
+    'Purchase order: PO-2024-0001.',
+])
+def test_false_positive_phone_isbn_identifiers(text):
+    """
+    False positive guard: phone numbers, ISBNs, and hyphen-joined IDs must
+    not be classified as dates.
+
+    Attack vector: Hyphen-delimited numeric identifiers. Phone numbers in
+    NANP format (NXX-NXX-XXXX) have three hyphen-separated components,
+    similar to MM-DD-YYYY. ISBNs have four components but the first is a
+    known prefix (978, 979, 0, etc.) that falls in month-range.
+
+    Why a parser might fail: A parser that tokenizes on hyphens and validates
+    only that there are three numeric groups may match the first three
+    components of a phone number. Similarly, a partial-ISBN match on 978-3-16
+    could confuse the parser into treating 3 as a month and 16 as a day.
+
+    Failure reveals: The parser lacks field-width and component-count
+    validation that would disambiguate these from calendar dates.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ===========================================================================
+# SECTION 8 -- BOUNDARY: YEAR RANGE ENFORCEMENT
+# ===========================================================================
+
+@pytest.mark.parametrize('text, expect_match', [
+    # Year boundary enforcement tests. The parser supports years [1926, 2036].
+    # These tests probe the exact boundaries and the values immediately outside.
+    ('Event on 01/01/1926.', True),
+    ('Event on 12/31/2036.', True),
+    ('Filed 06/15/1926.', True),
+    ('Filed 06/15/2036.', True),
+    ('Event on 01/01/1925.', False),
+    ('Filed 12/31/1924.', False),
+    ('Filed 01/01/1900.', False),
+    ('Filed 12/31/1800.', False),
+    ('Event on 01/01/2037.', False),
+    ('Filed 12/31/2038.', False),
+    ('Filed 01/01/2100.', False),
+    ('Filed 12/31/9999.', False),
+    ('Filed 06/15/1980.', True),
+    ('Filed 06/15/2000.', True),
+    ('Filed 06/15/2024.', True),
+    ('Filed 01/01/1927.', True),
+    ('Filed 12/31/2035.', True),
+    ('Filed 07/04/1976.', True),
+    ('Filed 06/06/1944.', True),
+    ('Filed 11/11/1935.', True),
+])
+def test_boundary_year_range(text, expect_match):
+    """
+    Boundary: year range enforcement at min=1926 and max=2036.
+
+    Attack vector: Dates with years at or beyond the documented supported
+    range. The parser claims to support years [1926, 2036]. Years outside
+    this range should be rejected; years at the exact boundary must be
+    accepted. Off-by-one errors at range boundaries are a classic parser bug.
+
+    Why a parser might fail: Boundary conditions (<= vs <, >= vs >) are
+    notoriously prone to implementation error. A parser using strict inequality
+    (year > 1926) instead of non-strict (year >= 1926) would incorrectly
+    reject the minimum boundary year.
+
+    Failure reveals: The year boundary condition uses an incorrect comparator
+    (off-by-one), causing the boundary years to be wrongly rejected or accepted.
+    """
+    result = extract_explicit_dates(text)
+    if expect_match:
+        assert len(result) > 0, f'Expected match for: {text!r}'
+    else:
+        assert len(result) == 0, f'Expected no match for: {text!r}'
+
+
+# ===========================================================================
+# SECTION 9 -- BOUNDARY: CALENDAR LOGIC (INVALID DATES)
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Calendar-invalid dates -- structurally match but are impossible calendar values.
+    'Filed on 01/00/2024.',
+    'Filed on 00/01/2024.',
+    'Filed on 13/01/2024.',
+    'Filed on 01/32/2024.',
+    'Filed on 02/30/2024.',
+    'Filed on 02/31/2024.',
+    'Filed on 04/31/2024.',
+    'Filed on 06/31/2024.',
+    'Filed on 09/31/2024.',
+    'Filed on 11/31/2024.',
+    'Filed on 99/99/9999.',
+    'Filed on 13/32/2024.',
+    'Filed on 02/29/2023.',
+    'Filed on 02/29/1900.',
+    'Filed on 02/29/1800.',
+    'Filed on 02/29/1700.',
+    'Filed on 12/00/2024.',
+    'Filed on 00/31/2024.',
+    'Filed on 13/13/2024.',
+])
+def test_boundary_calendar_invalid(text):
+    """
+    Boundary: calendar-invalid dates must be rejected.
+
+    Attack vector: Syntactically valid date strings that represent impossible
+    calendar values. Examples include month=0, day=0, month=13, day=32,
+    February 30, April 31, and non-leap-year February 29.
+
+    Why a parser might fail: Parsers that operate purely at the lexical level
+    (matching digit patterns) without a semantic validation pass will accept
+    any three-component numeric sequence whose components fall in a loose
+    numeric range. Without calendar-logic validation (including Gregorian
+    leap-year rules), invalid dates pass through undetected.
+
+    Failure reveals: The parser does not apply calendar-logic validation after
+    pattern matching, meaning it will accept impossible dates and potentially
+    confuse downstream consumers that rely on the parsed date being a real
+    calendar date.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ===========================================================================
+# SECTION 10 -- BOUNDARY: VALID LEAP YEAR FEBRUARY 29
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # February 29 is valid only in leap years.
+    # 2024 is a leap year (divisible by 4, not by 100).
+    # 2000 is a leap year (divisible by 400).
+    'Filed on 02/29/2024.',
+    'Filed on 02/29/2000.',
+    'Filed on 02/29/2028.',
+    'Filed on 02/29/1928.',
+    'Filed on 02/29/1932.',
+    'Filed on 02/29/1936.',
+    'Filed on 02/29/1940.',
+    'Filed on 02/29/1980.',
+])
+def test_boundary_valid_leap_year_feb29(text):
+    """
+    Boundary: February 29 in valid leap years must be accepted.
+
+    Attack vector: February 29 is the rarest calendar date and the one most
+    often handled incorrectly in date parsers. The Gregorian leap year rule
+    has three nested conditions (div-4, div-100, div-400) and parsers
+    frequently implement only the first condition (div-4), missing the
+    century correction.
+
+    Why a parser might fail: The parser correctly validates February 29 exists
+    only in leap years but either rejects all Feb 29 dates, accepts only the
+    simple div-4 case and rejects the div-400 case, or applies no leap year
+    check at all.
+
+    Failure reveals: The leap year validation logic is absent, incomplete, or
+    incorrectly applied to the div-100/div-400 century correction cases.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ===========================================================================
+# SECTION 11 -- UNICODE ATTACKS: HOMOGLYPHS AND ALTERNATE SCRIPTS
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Full-width digits (Unicode block: Fullwidth Digit, U+FF10..U+FF19).
+    # These are visually identical to ASCII digits but have different code points.
+    'Filed on ０４/０８/２０２４.',
+    # Arabic-Indic digits (U+0660..U+0669) -- used in Arabic, Persian, Urdu scripts.
+    'Filed on ٠٤/٠٨/٢٠٢٤.',
+    # Mathematical division slash (U+2215) homoglyph for /
+    'Filed on 04∕08∕2024.',
+    # Zero-width space (U+200B) injected between date components.
+    'Filed on 04/0​8/2024.',
+    'Filed on 04​/08/2024.',
+    # RTL override (U+202E) prefix
+    'Filed on ‮04/08/2024.',
+    # Non-breaking hyphen (U+2011)
+    'Filed on 04‑08‑2024.',
+    # En-dash (U+2013)
+    'Filed on 04–08–2024.',
+    # Em-dash (U+2014)
+    'Filed on 04—08—2024.',
+    # Soft hyphen (U+00AD)
+    'Filed on 04­08­2024.',
+    # Zero-width joiner (U+200D) between digits
+    'Filed on 04/‍08/2024.',
+    # Right-to-left mark (U+200F) before date
+    'Filed on ‏04/08/2024.',
+])
+def test_unicode_attacks(text):
+    """
+    Unicode attack: homoglyph and alternate script substitutions.
+
+    Attack vector: Unicode contains many characters that are visually
+    indistinguishable from or closely resemble ASCII punctuation and digits.
+    Adversarial inputs may substitute full-width digits, Arabic-Indic numerals,
+    mathematical division slashes, non-breaking hyphens, en-dashes, em-dashes,
+    zero-width spaces, and directional override characters.
+
+    Why a parser might fail: Regex-based parsers anchored to ASCII character
+    classes ([0-9], [-/\.]) will silently fail to match Unicode homoglyphs.
+    Conversely, parsers that normalize Unicode before matching may normalize
+    homoglyphs to their ASCII equivalents -- which could be either correct
+    behavior (normalization is desirable) or a security concern depending on
+    the application.
+
+    These tests are informational: we assert only that the parser does not
+    throw an exception, since the correct match/no-match outcome is product-
+    defined by the normalization policy.
+
+    Failure reveals: The parser raises an unhandled exception on Unicode input.
+    """
+    try:
+        result = extract_explicit_dates(text)
+        assert isinstance(result, dict)
+    except Exception as exc:
+        pytest.fail(
+            f'Parser raised exception on Unicode input: {exc!r}\nInput: {text!r}'
+        )
+
+
+# ===========================================================================
+# SECTION 12 -- ALL MONTHS: DAY RANGE COVERAGE (SLASH)
+# ===========================================================================
+
+@pytest.mark.parametrize('month,max_day', [
+    (1, 31), (2, 28), (3, 31), (4, 30),
+    (5, 31), (6, 30), (7, 31), (8, 31),
+    (9, 30), (10, 31), (11, 30), (12, 31),
+])
+def test_true_positive_month_day_range(month, max_day):
+    """
+    True positive: first and last day of every month must be detected.
+
+    Attack vector: Month-specific day-range limits. Different months have
+    different maximum day counts (28/29/30/31), and a parser must correctly
+    handle dates at both ends of each month range.
+
+    Why a parser might fail: Parsers that implement a single global day
+    upper bound (e.g., day <= 31) without month-awareness will accept invalid
+    dates like April 31, but may also incorrectly reject valid dates at
+    month boundaries if the bound is set too conservatively.
+
+    Failure reveals: Month-specific day bounds are not correctly applied,
+    either accepting invalid end-of-month dates or rejecting valid ones.
+    """
+    first = f'{month:02d}/01/2024'
+    last = f'{month:02d}/{max_day:02d}/2024'
+    for date_str in [first, last]:
+        result = extract_explicit_dates(f'Filed on {date_str}.')
+        assert len(result) > 0, f'Expected match for valid date: {date_str}'
+
+
+# ===========================================================================
+# SECTION 13 -- MIXED DELIMITER IN SAME SENTENCE
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Sentences containing multiple dates with different delimiters.
+    # The parser must correctly identify all dates regardless of which
+    # delimiter each uses.
+    'Compare 04/08/2024 with 04-08-2024.',
+    'The slash date 01/15/2023 and dot date 01.15.2023 are the same.',
+    'From 03-01-2024 to 03/31/2024.',
+    'Both 12.31.2023 and 12/31/2023 are year-end.',
+    'Filed 06-05-2016 and updated 06/05/2016.',
+    'Event 05.01.2024 confirmed; see also 05-01-2024.',
+    'Issued 01/01/2024; renewed 01-01-2025.',
+    'Quarter start 07/01/2024 and end 09.30.2024.',
+])
+def test_true_positive_mixed_delimiters_in_sentence(text):
+    """
+    True positive: multiple dates with different delimiters in one sentence.
+
+    Attack vector: A sentence containing two or more date references that
+    use different delimiter characters. The parser must not experience
+    delimiter-conflict where matching one format suppresses recognition
+    of another.
+
+    Why a parser might fail: If the parser uses a first-match strategy
+    (find first date, return), it will miss the second date. If the parser
+    state machine is confused by the delimiter switch mid-sentence, it may
+    produce partial or incorrect matches.
+
+    Failure reveals: The multi-date extraction loop either short-circuits
+    after the first match or has state contamination between delimiter modes.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) >= 2, f'Expected at least 2 dates in: {text!r}'

--- a/tests/red_team/test_rt_prose_year.py
+++ b/tests/red_team/test_rt_prose_year.py
@@ -1,0 +1,985 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+"""
+Red Team Test Suite -- Prose Year Patterns
+==========================================
+Target function : extract_explicit_dates(text: str) -> Dict[str, str]
+Target patterns : in 2024, since 2019, circa 2004, as of 2004, prior to 2010,
+                  from 2019, through 2019, by 2024, until 2030, before 2004,
+                  after 2004, during 2020, around 2019, back to 1998
+
+Related GitHub Issue:
+    #43 https://github.com/craigtrim/fast-parse-time/issues/43
+
+ATTACK SURFACE OVERVIEW
+------------------------
+Prose-year expressions require the parser to identify a temporal preposition
+or multi-word preposition adjacent to a 4-digit year and classify the result
+as YEAR_ONLY or TIMEFRAME_RELATIVE_TO_NOW. The attack vectors here are:
+
+  1. ALL PREPOSITIONS AT MULTIPLE YEARS: If the parser was tuned on only a
+     small set of year/preposition combinations, it may fail on the full cross-
+     product. Thirteen prepositions times a spread of 8+ years creates 100+
+     true-positive cases from this one dimension alone.
+
+  2. CASE VARIANTS: Prepositions are often encountered in ALL CAPS (headlines),
+     Title Case (sentence starts), and mixed case (transcription noise). The
+     parser must be case-insensitive.
+
+  3. SENTENCE EMBEDDING AND PUNCTUATION ADJACENCY: Years appear mid-sentence,
+     at sentence boundaries (trailing period), and comma-adjacent (clauses).
+     Anchored regexes and word-boundary-sensitive regexes will fail here.
+
+  4. MULTI-WORD PREPOSITIONS: "as of", "back to", and "prior to" each require
+     matching a two-word phrase before the year. These are a common oversight
+     in single-token preposition parsers.
+
+  5. OUT-OF-RANGE YEARS: If the parser enforces a valid year range (e.g.,
+     [1926, 2036]), then years outside that range must be rejected. Both
+     false-positive (the parser matches a year it should reject) and false-
+     negative (the parser misses a year it should accept) failures are tested.
+
+  6. NON-YEAR NUMBERS: Prepositions can appear near non-temporal numbers (port
+     numbers, version numbers, item counts). The parser must not tag "port 8080"
+     or "version 42" as date references.
+
+  7. UNICODE: Fullwidth digits, zero-width spaces, and RTL markers can defeat
+     ASCII-only regex patterns or produce unexpected matches through Python's
+     Unicode-aware \d matching.
+
+XFAIL STRATEGY
+--------------
+All tests carry ``pytestmark = pytest.mark.xfail`` so the suite remains green
+while the implementation is incomplete. An unexpected pass (xpass) is a
+promotion candidate.
+
+TRUE POSITIVE TESTS  ->  assert len(result) > 0
+FALSE POSITIVE TESTS ->  assert len(result) == 0
+BOUNDARY TESTS       ->  assert isinstance(result, dict)  (no direction)
+UNICODE TESTS        ->  assert isinstance(result, dict)  (no direction)
+"""
+
+import pytest
+from fast_parse_time.api import extract_explicit_dates
+
+# Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+
+pytestmark = pytest.mark.xfail(reason='red_team: not yet validated')
+
+
+# ============================================================================
+# SECTION 1 -- TRUE POSITIVES: ALL 13 PREPOSITIONS x 8 YEARS
+# ============================================================================
+#
+# The 13 prepositions under test are:
+#   in, since, circa, as of, prior to, from, through, by,
+#   until, before, after, during, around, back to
+#
+# The 8 year values span the valid range with historical and near-future
+# coverage: 1930, 1950, 1970, 1990, 2000, 2010, 2020, 2030.
+#
+# A truly general parser must handle every cell of this 14x8 matrix.
+# Each failure isolates a specific (preposition, year) gap.
+
+@pytest.mark.parametrize('text', [
+    # -- preposition: in --
+    'in 1930',
+    'in 1950',
+    'in 1970',
+    'in 1990',
+    'in 2000',
+    'in 2010',
+    'in 2020',
+    'in 2030',
+    # -- preposition: since --
+    'since 1930',
+    'since 1950',
+    'since 1970',
+    'since 1990',
+    'since 2000',
+    'since 2010',
+    'since 2020',
+    'since 2030',
+    # -- preposition: circa --
+    'circa 1930',
+    'circa 1950',
+    'circa 1970',
+    'circa 1990',
+    'circa 2000',
+    'circa 2010',
+    'circa 2020',
+    'circa 2030',
+    # -- multi-word preposition: as of --
+    'as of 1930',
+    'as of 1950',
+    'as of 1970',
+    'as of 1990',
+    'as of 2000',
+    'as of 2010',
+    'as of 2020',
+    'as of 2030',
+    # -- multi-word preposition: prior to --
+    'prior to 1930',
+    'prior to 1950',
+    'prior to 1970',
+    'prior to 1990',
+    'prior to 2000',
+    'prior to 2010',
+    'prior to 2020',
+    'prior to 2030',
+    # -- preposition: from --
+    'from 1930',
+    'from 1950',
+    'from 1970',
+    'from 1990',
+    'from 2000',
+    'from 2010',
+    'from 2020',
+    'from 2030',
+    # -- preposition: through --
+    'through 1930',
+    'through 1950',
+    'through 1970',
+    'through 1990',
+    'through 2000',
+    'through 2010',
+    'through 2020',
+    'through 2030',
+    # -- preposition: by --
+    'by 1930',
+    'by 1950',
+    'by 1970',
+    'by 1990',
+    'by 2000',
+    'by 2010',
+    'by 2020',
+    'by 2030',
+    # -- preposition: until --
+    'until 1930',
+    'until 1950',
+    'until 1970',
+    'until 1990',
+    'until 2000',
+    'until 2010',
+    'until 2020',
+    'until 2030',
+    # -- preposition: before --
+    'before 1930',
+    'before 1950',
+    'before 1970',
+    'before 1990',
+    'before 2000',
+    'before 2010',
+    'before 2020',
+    'before 2030',
+    # -- preposition: after --
+    'after 1930',
+    'after 1950',
+    'after 1970',
+    'after 1990',
+    'after 2000',
+    'after 2010',
+    'after 2020',
+    'after 2030',
+    # -- preposition: during --
+    'during 1930',
+    'during 1950',
+    'during 1970',
+    'during 1990',
+    'during 2000',
+    'during 2010',
+    'during 2020',
+    'during 2030',
+    # -- preposition: around --
+    'around 1930',
+    'around 1950',
+    'around 1970',
+    'around 1990',
+    'around 2000',
+    'around 2010',
+    'around 2020',
+    'around 2030',
+    # -- multi-word preposition: back to --
+    'back to 1930',
+    'back to 1950',
+    'back to 1970',
+    'back to 1990',
+    'back to 2000',
+    'back to 2010',
+    'back to 2020',
+    'back to 2030',
+])
+def test_prose_year_all_prepositions_true_positive(text):
+    """
+    Attack vector: all 14 supported prepositions (including multi-word forms)
+    paired with a spread of valid years across the supported range.
+
+    Why a parser might fail: a parser developed against a limited set of
+    (preposition, year) training pairs may produce a regex that accidentally
+    hard-codes those specific combinations. For example, a pattern like
+    ``(?:in|since) (?:2004|2019|2024)`` would pass only those 6 cases.
+
+    The multi-word prepositions ('as of', 'prior to', 'back to') require the
+    regex to match two consecutive tokens before the year. A single-token
+    preposition pattern like ``\\b(?:in|since|from)\\b\\s+\\d{4}`` will miss
+    all three multi-word forms, silently dropping real temporal references in
+    financial, legal, and historical texts where these constructions are common.
+
+    What failure reveals: each failing case identifies a specific preposition or
+    year value that the parser does not handle, enabling targeted remediation.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ============================================================================
+# SECTION 2 -- TRUE POSITIVES: CASE VARIANTS
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Uppercase prepositions (common in headlines, all-caps environments).
+    'IN 2024',
+    'SINCE 2019',
+    'CIRCA 2004',
+    'AS OF 2010',
+    'PRIOR TO 1998',
+    'FROM 2015',
+    'THROUGH 2020',
+    'BY 2024',
+    'UNTIL 2030',
+    'BEFORE 2004',
+    'AFTER 2004',
+    'DURING 2020',
+    'AROUND 2019',
+    'BACK TO 1998',
+    # Title case (sentence-initial).
+    'In 2024',
+    'Since 2019',
+    'Circa 2004',
+    'As Of 2010',
+    'Prior To 1998',
+    'From 2015',
+    'Through 2020',
+    'By 2024',
+    'Until 2030',
+    'Before 2004',
+    'After 2004',
+    'During 2020',
+    'Around 2019',
+    'Back To 1998',
+    # Mixed case (transcription noise, OCR errors).
+    'iN 2024',
+    'SiNCE 2019',
+    'CiRCA 2004',
+    'As oF 2010',
+    'PRIoR TO 1998',
+    'FrOM 2015',
+    'ThROUGH 2020',
+    'bY 2024',
+    'UnTIL 2030',
+    'BEFore 2004',
+    'AFTer 2004',
+    'DURing 2020',
+    'ArOUND 2019',
+    'BACK tO 1998',
+])
+def test_prose_year_case_variants_true_positive(text):
+    """
+    Attack vector: case variants of temporal prepositions (ALL CAPS, Title Case,
+    and mixed-case).
+
+    Why a parser might fail: a regex pattern that uses literal lowercase strings
+    without the ``re.IGNORECASE`` flag (or equivalent) will fail on all-caps and
+    title-case inputs. These are extremely common in real-world text: newspaper
+    headlines, legal documents, government reports, and transcription outputs from
+    speech-to-text systems frequently use non-lowercase prepositions.
+
+    The mixed-case variants ('iN 2024', 'SiNCE 2019') simulate OCR noise and
+    character substitution errors that arise when text is extracted from images or
+    scanned documents. A parser that is case-insensitive at the character level
+    (via ``re.IGNORECASE``) will handle all of these correctly.
+
+    What failure reveals: the parser performs case-sensitive matching, making it
+    brittle in real-world text processing pipelines that do not normalise case
+    before calling the API.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ============================================================================
+# SECTION 3 -- TRUE POSITIVES: SENTENCE EMBEDDED
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Years appear at sentence end (trailing period).
+    'things happened in 2024.',
+    'the policy was effective since 2019.',
+    'circa 2004.',
+    'as of 2010.',
+    'prior to 1998.',
+    # Years appear mid-sentence, comma-adjacent.
+    'results improved, since 2019, dramatically',
+    'the law, as of 2010, applies to all',
+    'revenue grew, from 2015, by 40%',
+    'operations, during 2020, were disrupted',
+    # Years appear after a comma-separated clause.
+    'after years of decline, in 2024 we saw recovery',
+    'despite challenges, by 2030 the project will complete',
+    'historically, around 2019, tensions peaked',
+    # Years embedded in longer sentences.
+    'the company was founded in 1970 and grew steadily',
+    'records show that since 1990 the trend has been upward',
+    'the regulation, which came into force before 2004, was repealed',
+    'profits after 2000 consistently exceeded projections',
+    'the system was in use through 2010 before replacement',
+    'we expect completion until 2030 at the latest',
+    'back to 1998, the data shows a clear pattern',
+    'from 2019 onwards the new methodology was applied',
+    # Sentence-initial year expression.
+    'In 2024 the market changed significantly.',
+    'Since 2019 we have observed consistent growth.',
+    'By 2030 all targets should be met.',
+    'Before 2004 the regulation did not apply.',
+    'After 2010 the sector recovered.',
+    # Year expression followed by additional date context.
+    'in 2024 and in 2019 the results were similar',
+    'from 2010 through 2020 the project ran continuously',
+])
+def test_prose_year_sentence_embedded_true_positive(text):
+    """
+    Attack vector: temporal prepositions with years embedded in prose sentences,
+    adjacent to punctuation, or at sentence boundaries.
+
+    Why a parser might fail: a regex anchored with ``^`` or ``$`` will only match
+    when the year expression is the entire input. More commonly, the regex uses
+    ``\\b`` (word boundary) which may not correctly span the transition between a
+    comma and the preposition, or between the year and a trailing period.
+
+    Comma-adjacent cases like '...since 2019, the...' are particularly tricky:
+    the comma is not a word character, so ``\\b`` between the comma and 'since'
+    may or may not fire depending on the regex engine's definition. A parser that
+    requires a space before the preposition will fail on '..., since...' (comma
+    immediately before the preposition without a space).
+
+    What failure reveals: the parser is brittle to punctuation context and cannot
+    reliably extract years from flowing prose.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ============================================================================
+# SECTION 4 -- TRUE POSITIVES: MULTI-WORD PREPOSITIONS WITH MULTIPLE YEARS
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # 'as of' with multiple year values.
+    'as of 2019',
+    'as of 1998',
+    'as of 2004',
+    'as of 2010',
+    'as of 2020',
+    'as of 2024',
+    'as of 2030',
+    'as of 1970',
+    'as of 1990',
+    # 'back to' with multiple year values.
+    'back to 1998',
+    'back to 2000',
+    'back to 2004',
+    'back to 2010',
+    'back to 2019',
+    'back to 2024',
+    'back to 1970',
+    'back to 1950',
+    'back to 1930',
+    # 'prior to' with multiple year values.
+    'prior to 2010',
+    'prior to 2000',
+    'prior to 2004',
+    'prior to 2019',
+    'prior to 2024',
+    'prior to 1990',
+    'prior to 1970',
+    'prior to 1950',
+    'prior to 1930',
+    # Mixed multi-word prepositions in one string.
+    'as of 2019 and prior to 2024',
+    'back to 1998 and as of 2010',
+    'prior to 2000 and back to 1990',
+])
+def test_prose_year_multi_word_prepositions_true_positive(text):
+    """
+    Attack vector: multi-word temporal prepositions ('as of', 'back to', 'prior to')
+    combined with a range of valid year values.
+
+    Why a parser might fail: a single-token preposition regex like
+    ``\\b(?:in|since|from|by|until|before|after|during|around|through|circa)\\b``
+    does not include the two-word forms. Adding 'as' would cause false positives on
+    "as soon as" or "as long as". The correct approach is to match the full two-word
+    phrase: ``as\\s+of``, ``back\\s+to``, ``prior\\s+to``.
+
+    The ``\\s+`` (one or more whitespace) between the words is important: user input
+    may contain a double space, a tab, or a non-breaking space between 'as' and 'of'.
+    A regex that uses a literal single space `` `` will miss these variants.
+
+    What failure reveals: the parser only handles single-token prepositions and
+    misses the three two-word forms, causing silent data loss on common expressions
+    found in financial reports ('as of 2019'), historical analyses ('back to 1998'),
+    and regulatory documents ('prior to 2010').
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ============================================================================
+# SECTION 5 -- FALSE POSITIVES: PREPOSITION + OUT-OF-RANGE YEAR
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Years below the minimum supported year (assumed: 1926 based on project codebase).
+    'in 1800',
+    'in 1850',
+    'in 1900',
+    'in 1920',
+    'in 1925',          # one below min (1926)
+    'since 1800',
+    'since 1850',
+    'since 1900',
+    'since 1925',
+    'by 1850',
+    'by 1900',
+    'by 1920',
+    'by 1925',
+    'from 1800',
+    'from 1900',
+    'from 1920',
+    'from 1925',
+    'before 1800',
+    'before 1900',
+    'before 1925',
+    'after 1800',
+    'circa 1800',
+    'around 1900',
+    'during 1850',
+    'back to 1800',
+    'as of 1900',
+    'prior to 1800',
+    # Years above the maximum supported year (assumed: 2036 based on project codebase).
+    'in 2037',          # one above max
+    'in 2040',
+    'in 2050',
+    'in 2090',
+    'in 2100',
+    'since 2050',
+    'since 2100',
+    'by 2037',
+    'by 2050',
+    'by 2100',
+    'from 2050',
+    'from 2100',
+    'until 2050',
+    'until 2100',
+    'before 2050',
+    'after 2050',
+    'through 2050',
+    'around 2050',
+    'back to 2050',
+    'as of 2050',
+])
+def test_prose_year_out_of_range_false_positive(text):
+    """
+    Attack vector: temporal prepositions paired with years outside the parser's
+    supported year range.
+
+    Why a parser might fail (producing a false positive): if the year-range guard
+    in the parser only validates years extracted by the prose-year sub-module but
+    not those extracted by other sub-modules, an out-of-range year may slip
+    through when a different code path is triggered.
+
+    Conversely, if the year-range guard is too strict (e.g., rejecting 1926 when
+    the documentation says 1926 is valid), then boundary-adjacent years will be
+    incorrectly rejected, producing false negatives.
+
+    The minimum boundary (1925 vs 1926) and maximum boundary (2036 vs 2037) cases
+    are included explicitly in the boundary section to provide unambiguous pass/fail
+    evidence for the off-by-one question.
+
+    What failure reveals (false positive produced): the parser is not enforcing
+    the year-range guard correctly, accepting years from the distant past or far
+    future that have no practical temporal significance in the supported domain.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ============================================================================
+# SECTION 6 -- FALSE POSITIVES: PREPOSITION + NON-YEAR NUMBER
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Small numbers that are not years.
+    'in 42',
+    'in 99',
+    'in 5',
+    'since 99',
+    'since 7',
+    'by 123',
+    'by 12',
+    'by 3',
+    'from 5',
+    'from 99',
+    'from 0',
+    'until 42',
+    'before 12',
+    'after 7',
+    'during 99',
+    'around 5',
+    'through 12',
+    'circa 50',
+    # 3-digit numbers (not 4-digit years).
+    'in 202',
+    'since 201',
+    'by 199',
+    'from 200',
+    'until 203',
+    'before 202',
+    'after 195',
+    'during 202',
+    # Large numbers (more than 4 digits).
+    'in 99999',
+    'since 10000',
+    'by 20240',
+    'from 20245',
+    # Zero.
+    'in 0',
+    'since 0',
+    'by 0',
+])
+def test_prose_year_non_year_number_false_positive(text):
+    """
+    Attack vector: temporal prepositions paired with numbers that are not 4-digit
+    years (2-digit, 3-digit, 5-digit, or zero).
+
+    Why a parser might fail (producing a false positive): a regex that uses
+    ``\\d+`` (any number of digits) rather than ``\\d{4}`` (exactly four digits)
+    will match 'in 42' and 'from 5'. Conversely, a regex that uses ``\\d{4,}``
+    (four or more digits) will also match 'in 20245', incorrectly treating a
+    5-digit number adjacent to a preposition as a year.
+
+    The parser must use exactly ``\\d{4}`` for the year group, and may further
+    validate that the 4-digit number falls within a plausible year range.
+
+    What failure reveals (false positive produced): the parser is matching
+    non-year numbers as year references, which would cause incorrect date
+    extraction from texts containing version numbers, item counts, or identifiers
+    that happen to appear after a temporal preposition.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ============================================================================
+# SECTION 7 -- FALSE POSITIVES: PREPOSITION + PARTIAL 4-DIGIT SEQUENCE
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # These look like year patterns but are actually partial sequences.
+    'in 202',           # 3 digits -- not a year
+    'from 20245',       # 5 digits -- not a year
+    'since 20',         # 2 digits -- not a year
+    'by 2',             # 1 digit -- not a year
+    'until 20249',      # 5 digits -- not a year
+    'in 20',
+    'before 20',
+    'after 202',
+    'around 2024a',     # 4 digits + alpha character
+    'in 2024abc',       # 4 digits immediately followed by alpha (may or may not be year)
+    'since 2024-',      # 4 digits followed by hyphen (could be start of YEAR-RANGE)
+    'by 2024x',
+    'from 2019z',
+])
+def test_prose_year_partial_sequence_false_positive(text):
+    """
+    Attack vector: prepositions adjacent to digit sequences that are almost but not
+    exactly 4-digit years.
+
+    Why a parser might fail (producing a false positive): a regex using ``\\d{4}``
+    without word-boundary anchoring (``\\b``) can match 4 digits anywhere in a
+    longer digit string. For example, ``in 20245`` would match 'in 2024' if the
+    regex does not require a word boundary or a non-digit character after the year.
+
+    The case of '2024a' and '2024abc' is interesting: the 4 digits are valid,
+    but the immediate alpha suffix may indicate a version identifier (2024a =
+    version 2024 alpha) rather than a year. This is a policy question: whether
+    the parser should be strict (require digit isolation) or lenient (accept
+    any 4-digit group preceded by a preposition). The test records current behaviour.
+
+    What failure reveals (false positive produced): the parser is matching digit
+    substrings within larger token sequences.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ============================================================================
+# SECTION 8 -- FALSE POSITIVES: CODE/TECH CONTEXTS
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Version assignments in code.
+    'version = 2024',
+    'VERSION = 2019',
+    'ver = 2004',
+    'v = 2010',
+    # Port numbers (common false-positive context).
+    'port 8080',
+    'port 443',
+    'port 8443',
+    'port 3000',
+    'port 5432',
+    'port 27017',
+    # ID/reference patterns.
+    'id: 2024',
+    'id: 2019',
+    'ref: 2019',
+    'id=2024',
+    'id=2019',
+    # Hash/issue reference.
+    '#2024',
+    '#2019',
+    '#2004',
+    # Error codes.
+    'error 2024',
+    'code 2019',
+    'status 2004',
+    # Year in a purely numeric context with no preposition.
+    '2024',
+    '2019',
+    '2004',
+    '2010',
+    '2020',
+    # Arithmetic or list context.
+    'items: 2024',
+    'count: 2019',
+    'total 2020',
+    # File names and paths.
+    'file2024.csv',
+    'report2019.pdf',
+    'log2020.txt',
+])
+def test_prose_year_code_tech_context_false_positive(text):
+    """
+    Attack vector: non-temporal numeric contexts where a 4-digit number that
+    happens to be a plausible year appears without a temporal preposition.
+
+    Why a parser might fail (producing a false positive): the prose-year extractor
+    is specifically designed to require a temporal preposition BEFORE the year.
+    However, if the preposition-detection logic has a bug that treats certain
+    non-preposition tokens ('id:', 'port', 'error', '#') as equivalent to
+    temporal prepositions, it will generate false positives.
+
+    Conversely, if another sub-module (year-only extractor, numeric-date extractor)
+    is too aggressive and treats any isolated 4-digit number in the range [1926,
+    2036] as a year reference, then the inputs "2024", "2019", etc. (with no
+    context at all) will produce false positives.
+
+    The port-number cases ('port 8080', 'port 443') test whether the parser
+    incorrectly treats 'port' as a temporal preposition. Port numbers are 4 digits
+    or fewer, so an out-of-range guard on the year value would correctly reject
+    them, but a parser without range validation would match 'port 443' as 'port
+    [year=443]' which would then fail only if 3-digit filtering is correct.
+
+    What failure reveals (false positive produced): the parser has over-broad
+    matching that does not require a genuine temporal preposition.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ============================================================================
+# SECTION 9 -- BOUNDARY: EXACT RANGE LIMITS
+# ============================================================================
+
+@pytest.mark.parametrize('text, expect_match', [
+    # Exact minimum -- should match (1926 is the stated floor).
+    ('in 1926',        True),
+    ('since 1926',     True),
+    ('from 1926',      True),
+    ('by 1926',        True),
+    ('as of 1926',     True),
+    ('back to 1926',   True),
+    ('prior to 1926',  True),
+    # Exact maximum -- should match (2036 is the stated ceiling).
+    ('by 2036',        True),
+    ('in 2036',        True),
+    ('since 2036',     True),
+    ('from 2036',      True),
+    ('until 2036',     True),
+    ('as of 2036',     True),
+    ('after 2036',     True),
+    # One below minimum -- should NOT match.
+    ('in 1925',        False),
+    ('since 1925',     False),
+    ('from 1925',      False),
+    ('by 1925',        False),
+    # One above maximum -- should NOT match.
+    ('by 2037',        False),
+    ('in 2037',        False),
+    ('since 2037',     False),
+    ('from 2037',      False),
+    ('until 2037',     False),
+])
+def test_prose_year_boundary(text, expect_match):
+    """
+    Attack vector: years at the exact boundary of the supported range (1926 and
+    2036) and one step beyond in each direction (1925 and 2037).
+
+    Why a parser might fail: off-by-one errors in range guards are among the most
+    common bugs in parser implementations. A guard written as ``year >= 1927``
+    instead of ``year >= 1926`` will silently reject all inputs containing 'in 1926'
+    even though 1926 is explicitly listed as valid.
+
+    Similarly, a guard written as ``year <= 2035`` will reject 'by 2036', and a
+    guard written as ``year < 2037`` will (correctly) reject 'by 2037' but this
+    is equivalent to ``year <= 2036`` and should produce the same result.
+
+    This test is parametrised with explicit expected outcomes (True/False) so that
+    a single test function verifies both inclusion and exclusion behaviour, making
+    it trivial to find the exact off-by-one value in a failing run.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    if expect_match:
+        assert len(result) > 0
+    else:
+        assert len(result) == 0
+
+
+# ============================================================================
+# SECTION 10 -- UNICODE: HOMOGLYPH AND INVISIBLE CHARACTER ATTACKS
+# ============================================================================
+
+@pytest.mark.parametrize('text, description', [
+    # Fullwidth digits (U+FF10-U+FF19) in place of ASCII digits.
+    # Python's re.UNICODE flag (default) may match these via \d, causing
+    # unexpected matches on what looks like a valid year but isn't.
+    ('in \uFF12\uFF10\uFF12\uFF14', 'fullwidth digits for 2024 (in ２０２４)'),
+    ('since \uFF12\uFF10\uFF11\uFF19', 'fullwidth digits for 2019 (since ２０１９)'),
+    ('by \uFF12\uFF10\uFF12\uFF14', 'fullwidth digits for 2024 (by ２０２４)'),
+    ('from \uFF12\uFF10\uFF10\uFF10', 'fullwidth digits for 2000 (from ２０００)'),
+    ('as of \uFF12\uFF10\uFF12\uFF10', 'fullwidth digits for 2020 (as of ２０２０)'),
+
+    # Zero-width space (U+200B) injected between preposition and year.
+    # This breaks word-boundary detection without being visually apparent.
+    ('in\u200B2024', "zero-width space between 'in' and year (U+200B)"),
+    ('since\u200B2019', "zero-width space between 'since' and year (U+200B)"),
+    ('from\u200B2010', "zero-width space between 'from' and year (U+200B)"),
+
+    # Zero-width space between preposition words in multi-word prepositions.
+    ('as\u200Bof 2019', "zero-width space inside 'as of' (U+200B)"),
+    ('prior\u200Bto 2010', "zero-width space inside 'prior to' (U+200B)"),
+    ('back\u200Bto 1998', "zero-width space inside 'back to' (U+200B)"),
+
+    # RTL override (U+202E) injected mid-expression.
+    ('in \u202E2024', 'RTL override before year (U+202E)'),
+    ('since \u202E2019', 'RTL override before year (U+202E)'),
+
+    # Arabic-Indic digits (U+0660-U+0669).
+    ('in \u0662\u0660\u0662\u0664', 'Arabic-Indic digits for 2024'),
+    ('since \u0662\u0660\u0661\u0669', 'Arabic-Indic digits for 2019'),
+
+    # Non-breaking space (U+00A0) in place of regular space between preposition and year.
+    # A regex using literal \\s should match this (\\s includes U+00A0 in Python 3),
+    # but one using a literal ASCII space (' ') will not.
+    ('in\u00A02024', "non-breaking space between 'in' and year (U+00A0)"),
+    ('since\u00A02019', "non-breaking space between 'since' and year (U+00A0)"),
+    ('from\u00A02010', "non-breaking space between 'from' and year (U+00A0)"),
+    ('as of\u00A02019', "non-breaking space after 'as of' (U+00A0)"),
+    ('back to\u00A01998', "non-breaking space after 'back to' (U+00A0)"),
+])
+def test_prose_year_unicode(text, description):
+    """
+    Attack vector: Unicode homoglyphs and invisible characters in prose-year
+    expressions -- specifically fullwidth digits, zero-width spaces, RTL
+    override characters, Arabic-Indic numerals, and non-breaking spaces.
+
+    Why a parser might be fooled by fullwidth digits: Python's ``re`` module with
+    the default ``re.UNICODE`` flag matches fullwidth digits (U+FF10-U+FF19) via
+    ``\\d``. A regex pattern ``\\d{4}`` will therefore match four fullwidth digits
+    that look like a year. Whether this is desirable (maximum recall) or undesirable
+    (strict ASCII-only matching) is a policy decision.
+
+    Why a parser might be broken by zero-width space: a zero-width space (U+200B)
+    inserted between the preposition and the year ('in\u200B2024') will cause a
+    regex that uses ``\\s+`` to fail because U+200B is a word character boundary
+    in some regex implementations. In Python 3, ``\\s`` does NOT match U+200B by
+    default (it only matches Unicode-defined whitespace in category Zs), so
+    'in\u200B2024' would cause the regex to not find a whitespace between 'in'
+    and '2024', failing the match.
+
+    Why non-breaking space matters: U+00A0 (NBSP) IS in Python's ``\\s`` class,
+    so 'in\u00A02024' should match with a properly written ``\\s+`` separator.
+    A regex using a literal space (' ') would miss it.
+
+    This test records current behaviour without a directional assertion so the
+    maintainer can decide the appropriate normalisation policy.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert isinstance(result, dict)
+
+
+# ============================================================================
+# SECTION 11 -- ADDITIONAL TRUE POSITIVES (reaching 250+ total cases)
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Additional preposition × year combinations not covered in section 1.
+    'in 2024',
+    'in 2019',
+    'in 2004',
+    'in 2008',
+    'in 2015',
+    'in 2016',
+    'in 2017',
+    'in 2018',
+    'in 2021',
+    'in 2022',
+    'in 2023',
+    'in 2025',
+    'in 2026',
+    'in 2027',
+    'in 2028',
+    'in 2029',
+    'in 2031',
+    'in 2032',
+    'in 2033',
+    'in 2034',
+    'in 2035',
+    'in 2036',
+    'in 1926',
+    'in 1927',
+    'in 1940',
+    'in 1945',
+    'in 1955',
+    'in 1960',
+    'in 1965',
+    'in 1975',
+    'in 1980',
+    'in 1985',
+    'in 1995',
+    'in 1998',
+    'since 2024',
+    'since 2004',
+    'since 2008',
+    'since 2015',
+    'since 2017',
+    'since 2022',
+    'since 1940',
+    'since 1965',
+    'since 1980',
+    'circa 2019',
+    'circa 2010',
+    'circa 1970',
+    'circa 1960',
+    'circa 1945',
+    'from 2019',
+    'from 2004',
+    'from 2008',
+    'from 1970',
+    'from 1960',
+    'through 2024',
+    'through 2019',
+    'through 2010',
+    'through 1990',
+    'by 2019',
+    'by 2010',
+    'by 2004',
+    'by 1990',
+    'by 1960',
+    'until 2019',
+    'until 2024',
+    'until 2010',
+    'until 1990',
+    'before 2019',
+    'before 2010',
+    'before 1990',
+    'before 1970',
+    'after 2019',
+    'after 2010',
+    'after 1990',
+    'after 1970',
+    'during 2019',
+    'during 2010',
+    'during 2004',
+    'during 1990',
+    'during 1970',
+    'around 2024',
+    'around 2010',
+    'around 2004',
+    'around 1990',
+    'around 1970',
+    'as of 2024',
+    'as of 2004',
+    'as of 2000',
+    'as of 1990',
+    'as of 1970',
+    'back to 2010',
+    'back to 2004',
+    'back to 2000',
+    'back to 1990',
+    'back to 1970',
+    'prior to 2024',
+    'prior to 2019',
+    'prior to 2004',
+    'prior to 1990',
+    'prior to 1970',
+    # Embedded in longer sentences (additional variety).
+    'the policy has been in place since 2010 and remains active',
+    'changes during 2020 affected all departments',
+    'completion is expected by 2030 or sooner',
+    'established around 1970, the institution has grown',
+    'regulations in force before 2004 were superseded',
+    'growth after 2000 was particularly strong',
+    'the project ran from 2015 through 2020',
+    'as of 2024, the framework is considered mature',
+    'dating back to 1990, the protocol remains relevant',
+    'prior to 2010 no such requirement existed',
+])
+def test_prose_year_additional_true_positive(text):
+    """
+    Attack vector: additional preposition + year combinations spanning the full
+    valid range, plus sentence-embedded examples for broader coverage.
+
+    Why a parser might fail: the prose-year parser may have been tuned on a limited
+    vocabulary of prepositions or a narrow year range. This section systematically
+    exercises all prepositions across many different valid years to discover any
+    coverage gaps not caught by the primary matrix in section 1.
+
+    What failure reveals: a specific (preposition, year) combination that the parser
+    does not handle, enabling targeted regex or pattern expansion.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0

--- a/tests/red_team/test_rt_quantifiers.py
+++ b/tests/red_team/test_rt_quantifiers.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+"""
+Red Team: Quantifier Patterns (a few days ago, couple of weeks ago, several months ago)
+Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+"""
+import pytest
+from fast_parse_time.api import extract_relative_times
+pytestmark = pytest.mark.xfail(reason='red_team: not yet validated')
+
+_FRAMES_P = ['seconds','minutes','hours','days','weeks','months','years','decades']
+
+# ── TRUE POSITIVES: "a few" × all frames ─────────────────────────────────────
+_TP_A_FEW = [f'a few {f} ago' for f in _FRAMES_P]
+@pytest.mark.parametrize('text', _TP_A_FEW)
+def test_tp_a_few_all_frames(text):
+    """'a few FRAME ago' for all 8 frames. Failure: 'a few' quantifier not in KB."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: "few" (no article) ───────────────────────────────────────
+_TP_FEW = [f'few {f} ago' for f in _FRAMES_P]
+@pytest.mark.parametrize('text', _TP_FEW)
+def test_tp_few_no_article(text):
+    """'few FRAME ago' (article omitted). Failure: article required for 'few' matching."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: "a couple of" ────────────────────────────────────────────
+_TP_COUPLE_OF = [f'a couple of {f} ago' for f in _FRAMES_P]
+@pytest.mark.parametrize('text', _TP_COUPLE_OF)
+def test_tp_a_couple_of_all_frames(text):
+    """'a couple of FRAME ago' for all 8 frames. Failure: 'couple of' not in KB."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: "couple of" (no article) ─────────────────────────────────
+_TP_COUPLE = [f'couple of {f} ago' for f in _FRAMES_P]
+@pytest.mark.parametrize('text', _TP_COUPLE)
+def test_tp_couple_of_no_article(text):
+    """'couple of FRAME ago' without 'a'. Failure: 'a' required for 'couple' matching."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: "several" ────────────────────────────────────────────────
+_TP_SEVERAL = [f'several {f} ago' for f in _FRAMES_P]
+@pytest.mark.parametrize('text', _TP_SEVERAL)
+def test_tp_several_all_frames(text):
+    """'several FRAME ago' for all 8 frames. Failure: 'several' not in quantifier KB."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: future quantifiers ───────────────────────────────────────
+_TP_FUTURE = (
+    [f'a few {f} from now' for f in _FRAMES_P] +
+    [f'a couple of {f} from now' for f in _FRAMES_P] +
+    [f'in a few {f}' for f in _FRAMES_P]
+)
+@pytest.mark.parametrize('text', _TP_FUTURE)
+def test_tp_future_quantifiers(text):
+    """Quantifiers in future forms ('a few days from now', 'in a few days').
+    Failure: quantifiers not supported in future tense expressions."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: sentence embedded ────────────────────────────────────────
+_TP_EMBEDDED = [
+    'the outage occurred a few hours ago during peak traffic',
+    'we saw this a couple of weeks ago in production',
+    'a few months ago the team decided to refactor',
+    'several years ago this was common practice',
+    'a couple of days ago the logs showed anomalies',
+]
+@pytest.mark.parametrize('text', _TP_EMBEDDED)
+def test_tp_sentence_embedded_quantifiers(text):
+    """Quantifier temporal expressions in natural prose. Failure: context breaks extraction."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── FALSE POSITIVES: quantifier + non-temporal noun ──────────────────────────
+_FP_NON_TEMPORAL = [
+    'a few good men','a few miles away','a couple of beers','a couple of items',
+    'several miles from here','several pages long','a few hundred dollars',
+    'a few dozen eggs','a couple of friends','several floors up',
+    'a few more questions','couple of chairs','several books',
+]
+@pytest.mark.parametrize('text', _FP_NON_TEMPORAL)
+def test_fp_quantifier_with_non_temporal_noun(text):
+    """Quantifiers followed by non-temporal unit nouns (miles, beers, eggs, etc).
+    Failure: 'a few' matched regardless of whether the following noun is a time unit."""
+    assert len(extract_relative_times(text)) == 0
+
+# ── BOUNDARY ──────────────────────────────────────────────────────────────────
+def test_boundary_double_quantifier():
+    """'couple of couple of weeks ago' — malformed double quantifier. Should not crash."""
+    extract_relative_times('couple of couple of weeks ago')
+
+def test_boundary_several_repeated():
+    """'several several months ago' — malformed. Should not crash."""
+    extract_relative_times('several several months ago')
+
+def test_boundary_quantifier_no_unit():
+    """'a few ago' — quantifier without time unit. Should not match."""
+    assert len(extract_relative_times('a few ago')) == 0

--- a/tests/red_team/test_rt_relative_ago_back.py
+++ b/tests/red_team/test_rt_relative_ago_back.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+"""
+Red Team: Relative Past Expressions (5 days ago, 10 hours back, 100 years ago)
+Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+"""
+import pytest
+from fast_parse_time.api import extract_relative_times
+pytestmark = pytest.mark.xfail(reason='red_team: not yet validated')
+
+_FRAMES = ['second','minute','hour','day','week','month','year','decade']
+_FRAMES_PLURAL = ['seconds','minutes','hours','days','weeks','months','years','decades']
+_ABBR = [('sec','secs'),('min','mins'),('hr','hrs'),('day','days'),
+         ('wk','wks'),('mo','mos'),('yr','yrs'),('decade','decades')]
+
+# ── TRUE POSITIVES: all 8 frames × ago × cardinality 1,5,10,100 ─────────────
+_TP_AGO = (
+    [f'1 {f} ago' for f in _FRAMES] +
+    [f'1 {f} ago' for f in _FRAMES_PLURAL] +
+    [f'5 {f} ago' for f in _FRAMES_PLURAL] +
+    [f'10 {f} ago' for f in _FRAMES_PLURAL] +
+    [f'100 {f} ago' for f in _FRAMES_PLURAL] +
+    [f'30 {f} ago' for f in _FRAMES_PLURAL] +
+    [f'365 {f} ago' for f in _FRAMES_PLURAL] +
+    [f'52 {f} ago' for f in _FRAMES_PLURAL]
+)
+
+@pytest.mark.parametrize('text', _TP_AGO)
+def test_tp_all_frames_ago(text):
+    """All 8 time frames with 'ago' terminal, multiple cardinalities.
+    Failure: frame or cardinality not supported in ago-form."""
+    assert len(extract_relative_times(text)) > 0
+
+_TP_BACK = (
+    [f'1 {f} back' for f in _FRAMES] +
+    [f'1 {f} back' for f in _FRAMES_PLURAL] +
+    [f'5 {f} back' for f in _FRAMES_PLURAL] +
+    [f'10 {f} back' for f in _FRAMES_PLURAL] +
+    [f'100 {f} back' for f in _FRAMES_PLURAL]
+)
+
+@pytest.mark.parametrize('text', _TP_BACK)
+def test_tp_all_frames_back(text):
+    """All 8 time frames with 'back' terminal marker.
+    Failure: 'back' not recognised as past-tense terminal."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: abbreviated unit forms ────────────────────────────────────
+_TP_ABBR = (
+    [f'5 {sg} ago' for sg, _ in _ABBR] +
+    [f'5 {pl} ago' for _, pl in _ABBR] +
+    [f'3 {sg} back' for sg, _ in _ABBR] +
+    [f'3 {pl} back' for _, pl in _ABBR]
+)
+
+@pytest.mark.parametrize('text', _TP_ABBR)
+def test_tp_abbreviated_unit_forms(text):
+    """Abbreviated time unit forms (sec, min, hr, wk, mo, yr, etc).
+    Failure: abbreviations not in unit lexicon."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: sentence embedded ────────────────────────────────────────
+_TP_EMBEDDED = [
+    'the incident occurred 5 days ago in the morning',
+    'we saw this 3 weeks back during testing',
+    'the outage 10 hours ago was resolved',
+    'this bug was introduced 6 months ago',
+    '2 years ago we redesigned the system',
+    'the meeting 30 minutes ago ran long',
+    'an update 1 year ago changed the behaviour',
+    'performance degraded 2 weeks back',
+]
+
+@pytest.mark.parametrize('text', _TP_EMBEDDED)
+def test_tp_sentence_embedded(text):
+    """Relative past expressions embedded in prose sentences.
+    Failure: surrounding context breaks relative time extraction."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: large cardinalities ─────────────────────────────────────
+_TP_LARGE = [
+    '365 days ago','730 days ago','999 days ago',
+    '52 weeks ago','104 weeks ago',
+    '24 hours ago','48 hours ago','72 hours ago',
+    '12 months ago','24 months ago',
+    '3 years ago','5 years ago','10 years ago','50 years ago','100 years ago',
+]
+
+@pytest.mark.parametrize('text', _TP_LARGE)
+def test_tp_large_cardinalities(text):
+    """Large numeric cardinalities with 'ago'. Failure: upper cardinality limit too low."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── FALSE POSITIVES: non-temporal units ──────────────────────────────────────
+_FP_NON_TEMPORAL = [
+    '5 miles ago','3 pages back','10 floors ago','2 chapters back',
+    '7 steps ago','4 items back','6 blocks ago','8 songs back',
+    '3 rows ago','5 seats back','10 questions ago','2 levels back',
+    '4 moves ago','12 rounds back','3 innings ago',
+]
+
+@pytest.mark.parametrize('text', _FP_NON_TEMPORAL)
+def test_fp_non_temporal_units(text):
+    """Non-temporal unit nouns after cardinality + ago/back (miles, pages, floors).
+    Failure: 'ago'/'back' matched regardless of whether preceding noun is a time unit."""
+    assert len(extract_relative_times(text)) == 0
+
+# ── FALSE POSITIVES: ago/back without quantity ────────────────────────────────
+_FP_NO_QTY = [
+    'the meeting, ago','long ago','ages ago','years and years ago',
+    'he went back','back to school','set things back','holding back',
+    'step back','back in the day','way back','a while back',
+    'once upon a time, long ago',
+]
+
+@pytest.mark.parametrize('text', _FP_NO_QTY)
+def test_fp_ago_back_without_quantity(text):
+    """'ago' and 'back' used without a specific numeric or quantifier cardinality.
+    'Long ago' and 'a while back' should not yield structured RelativeTime.
+    Failure: unanchored ago/back matched without cardinality."""
+    assert len(extract_relative_times(text)) == 0
+
+# ── BOUNDARY: edge cardinalities ─────────────────────────────────────────────
+def test_boundary_zero_cardinality():
+    """0 days ago — degenerate cardinality. Behavior undefined (same as 'now'?).
+    xfail: zero cardinality semantics not defined."""
+    result = extract_relative_times('0 days ago')
+    # If matched, cardinality should be 0
+    if result:
+        assert result[0].cardinality == 0
+
+def test_boundary_very_large_cardinality():
+    """999999 days ago — extreme cardinality. Should match if no upper bound.
+    Failure: arbitrary upper bound on cardinality blocks large values."""
+    assert len(extract_relative_times('999999 days ago')) > 0
+
+def test_boundary_negative_cardinality():
+    """-5 days ago — negative cardinality. Should NOT match (nonsensical).
+    Failure: negative numbers matched as cardinalities."""
+    assert len(extract_relative_times('-5 days ago')) == 0
+
+# ── UNICODE: digit homoglyphs ─────────────────────────────────────────────────
+_UNICODE = [
+    '⁵ days ago',          # superscript 5
+    '② days ago',          # circled 2
+    '٥ days ago',          # Arabic-Indic 5
+    '5​ days ago',         # ZWS between digit and space
+    '５ days ago',          # fullwidth 5
+    '৫ days ago',          # Bengali 5
+    '5̈ days ago',         # combining diaeresis on 5
+]
+
+@pytest.mark.parametrize('text', _UNICODE)
+def test_unicode_digit_homoglyphs_ago(text):
+    """Non-ASCII digit homoglyphs in cardinality position of 'ago' expressions.
+    Failure: Unicode digits accepted as cardinalities (may cause silent errors)."""
+    assert len(extract_relative_times(text)) == 0

--- a/tests/red_team/test_rt_relative_from_now.py
+++ b/tests/red_team/test_rt_relative_from_now.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+"""
+Red Team: Relative Future Expressions (5 days from now, in 3 months, in 1 year)
+Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+"""
+import pytest
+from fast_parse_time.api import extract_relative_times
+pytestmark = pytest.mark.xfail(reason='red_team: not yet validated')
+
+_FRAMES_P = ['seconds','minutes','hours','days','weeks','months','years','decades']
+_FRAMES_S = ['second','minute','hour','day','week','month','year','decade']
+
+# ── TRUE POSITIVES: N units from now ─────────────────────────────────────────
+_TP_FROM_NOW = (
+    [f'1 {f} from now' for f in _FRAMES_S] +
+    [f'1 {f} from now' for f in _FRAMES_P] +
+    [f'5 {f} from now' for f in _FRAMES_P] +
+    [f'10 {f} from now' for f in _FRAMES_P] +
+    [f'30 {f} from now' for f in _FRAMES_P] +
+    [f'100 {f} from now' for f in _FRAMES_P] +
+    [f'365 {f} from now' for f in _FRAMES_P]
+)
+
+@pytest.mark.parametrize('text', _TP_FROM_NOW)
+def test_tp_all_frames_from_now(text):
+    """All 8 frames with 'from now' terminal, multiple cardinalities.
+    Failure: frame or cardinality not supported in from-now form."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: in N units ────────────────────────────────────────────────
+_TP_IN_N = (
+    [f'in 1 {f}' for f in _FRAMES_S] +
+    [f'in 1 {f}' for f in _FRAMES_P] +
+    [f'in 5 {f}' for f in _FRAMES_P] +
+    [f'in 10 {f}' for f in _FRAMES_P] +
+    [f'in 30 {f}' for f in _FRAMES_P] +
+    [f'in 100 {f}' for f in _FRAMES_P]
+)
+
+@pytest.mark.parametrize('text', _TP_IN_N)
+def test_tp_in_n_units_form(text):
+    """All 8 frames in 'in N UNIT' future form.
+    Failure: 'in N UNIT' form not recognised or conflicts with prose-year 'in 2024'."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: abbreviated units ────────────────────────────────────────
+_TP_ABBR = [
+    '5 secs from now','3 mins from now','2 hrs from now','4 wks from now',
+    '6 mos from now','2 yrs from now','in 5 secs','in 3 mins','in 2 hrs',
+    'in 4 wks','in 6 mos','in 2 yrs',
+]
+
+@pytest.mark.parametrize('text', _TP_ABBR)
+def test_tp_abbreviated_units_future(text):
+    """Abbreviated time unit forms in future expressions.
+    Failure: abbreviations not in unit lexicon for future tense."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: sentence embedded ────────────────────────────────────────
+_TP_EMBEDDED = [
+    'the meeting is in 5 days','delivery expected in 3 weeks from now',
+    'the deadline is 2 months from now','launch scheduled in 6 months',
+    'renewal in 1 year from now','review in 30 days',
+    'contract expires in 2 years','patch due in 48 hours from now',
+]
+
+@pytest.mark.parametrize('text', _TP_EMBEDDED)
+def test_tp_sentence_embedded_future(text):
+    """Future expressions embedded in prose. Failure: context breaks extraction."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── FALSE POSITIVES: 'in YEAR' — YEAR_ONLY, not relative future ─────────────
+_FP_IN_YEAR = [
+    'in 2024','in 2020','in 1998','in 2030','in 1990','in 2010',
+    'in 1926','in 2036','in 2000','in 1980',
+]
+
+@pytest.mark.parametrize('text', _FP_IN_YEAR)
+def test_fp_in_year_not_relative_future(text):
+    """'in YYYY' should resolve to YEAR_ONLY explicit date, not relative future.
+    Critical disambiguation: 'in 2024' ≠ 'in 2024 days from now'.
+    Failure: year-with-preposition matched as relative future."""
+    result = extract_relative_times(text)
+    # If matched, it should NOT have a cardinality of 2024 with frame=year
+    for r in result:
+        assert not (r.cardinality > 1900 and r.frame == 'year')
+
+# ── FALSE POSITIVES: non-temporal 'in N' forms ────────────────────────────────
+_FP_NON_TEMPORAL = [
+    'in 5 minutes of fame','in 3 acts','in 2 parts','in 10 pieces',
+    'in 4 chapters','in 6 installments','in 3 volumes',
+    'from now on','starting from now','as of now',
+    '5 days from today',  # 'today' not 'now'
+]
+
+@pytest.mark.parametrize('text', _FP_NON_TEMPORAL)
+def test_fp_non_temporal_in_n_forms(text):
+    """'in N' constructs with non-temporal units, and bare 'from now' without quantity.
+    Failure: non-temporal 'in N' form matched as relative future."""
+    result = extract_relative_times(text)
+    # Allow zero results or results where frame is not a time unit
+    for r in result:
+        assert r.frame in ('second','minute','hour','day','week','month','year','decade')
+
+# ── BOUNDARY: edge cases ──────────────────────────────────────────────────────
+def test_boundary_zero_future():
+    """in 0 days — degenerate future. Behavior undefined. xfail."""
+    extract_relative_times('in 0 days')  # should not raise
+
+def test_boundary_very_large_future():
+    """in 999999 days — extreme future cardinality."""
+    assert len(extract_relative_times('in 999999 days')) > 0
+
+def test_boundary_negative_future():
+    """in -5 days — nonsensical. Should not match."""
+    assert len(extract_relative_times('in -5 days')) == 0

--- a/tests/red_team/test_rt_special_words.py
+++ b/tests/red_team/test_rt_special_words.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+"""
+Red Team: Special Temporal Words (today, yesterday, tomorrow, tonight, now, right now)
+Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+"""
+import pytest
+from fast_parse_time.api import extract_relative_times
+pytestmark = pytest.mark.xfail(reason='red_team: not yet validated')
+
+_WORDS = ['today','yesterday','tomorrow','tonight','now','right now']
+
+# ── TRUE POSITIVES: isolated ─────────────────────────────────────────────────
+@pytest.mark.parametrize('word', _WORDS)
+def test_tp_isolated_special_words(word):
+    """Each of the 6 special temporal words in isolation.
+    Failure: special word not in the KB or not recognized standalone."""
+    assert len(extract_relative_times(word)) > 0
+
+# ── TRUE POSITIVES: uppercase ─────────────────────────────────────────────────
+_TP_UPPER = ['TODAY','YESTERDAY','TOMORROW','TONIGHT','NOW','RIGHT NOW']
+@pytest.mark.parametrize('text', _TP_UPPER)
+def test_tp_uppercase(text):
+    """Special temporal words in full uppercase. Failure: case-sensitive matching."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: mixed case ────────────────────────────────────────────────
+_TP_MIXED = ['Today','Yesterday','Tomorrow','Tonight','Now','Right Now',
+             'ToDay','YeStErDaY','TOMORROW','ToNiGhT']
+@pytest.mark.parametrize('text', _TP_MIXED)
+def test_tp_mixed_case(text):
+    """Mixed-case special temporal words. Failure: not case-insensitive."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: sentence start/middle/end ────────────────────────────────
+_TP_SENTENCE = [
+    'Today I went to the store','Yesterday the report was filed',
+    'Tomorrow we ship the release','Tonight there is a meeting',
+    'I said today to proceed','we noted yesterday that the test failed',
+    'planning to ship tomorrow with the hotfix',
+    'See you tomorrow.','I will do it today.','He said yesterday.',
+    'We finish tonight.', 'The status is good right now.',
+    'Let me check on it now and get back to you.',
+]
+@pytest.mark.parametrize('text', _TP_SENTENCE)
+def test_tp_sentence_embedded(text):
+    """Special temporal words in natural sentence positions (start, middle, end).
+    Failure: sentence context breaks special-word extraction."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: possessives ──────────────────────────────────────────────
+_TP_POSSESSIVE = [
+    "today's meeting","tomorrow's forecast","yesterday's results",
+    "tonight's agenda","today's report","tomorrow's deadline",
+]
+@pytest.mark.parametrize('text', _TP_POSSESSIVE)
+def test_tp_possessives(text):
+    """Special temporal words with possessive 's suffix.
+    Whether the parser extracts the root is a design decision; the test
+    checks that the word is at minimum recognized in possessive form."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── FALSE POSITIVES: substring containment ───────────────────────────────────
+_FP_SUBSTRING = [
+    'nowadays','nowhere','know','renown','snowfall','knowhow',
+    'overthrow','elbow','meow','below','bestow','follow','hollow',
+    'daybreak','everyday','birthday','holiday','sundry',
+    'goodnight','fortnight','midnight','highlight','insight',
+]
+@pytest.mark.parametrize('text', _FP_SUBSTRING)
+def test_fp_substring_containment(text):
+    """Words containing temporal keywords as substrings (now in 'nowadays', etc).
+    Failure: substring match produces false positive on non-temporal word."""
+    assert len(extract_relative_times(text)) == 0
+
+# ── FALSE POSITIVES: negated or qualified ────────────────────────────────────
+_FP_QUALIFIED = [
+    'not today','not now','not tomorrow',
+    'maybe tomorrow','possibly tonight','perhaps yesterday',
+    'some day','any day','every day','each day',
+]
+@pytest.mark.parametrize('text', _FP_QUALIFIED)
+def test_fp_negated_and_qualified(text):
+    """Temporal words with negation or qualification. Behavior is ambiguous —
+    'not today' still contains 'today'. This tests whether the parser extracts
+    the word regardless of surrounding negation (which is the simpler correct approach).
+    xfail: the correct behavior is design-dependent."""
+    # This is intentionally ambiguous — we assert no crash, and note xfail covers outcome
+    extract_relative_times(text)  # should not raise
+
+# ── BOUNDARY: multiple in one string ─────────────────────────────────────────
+def test_boundary_multiple_special_words():
+    """'yesterday and today and tomorrow' — should yield 3 RelativeTime results.
+    Failure: only first or last match extracted from multi-temporal string."""
+    result = extract_relative_times('yesterday and today and tomorrow')
+    assert len(result) >= 2
+
+def test_boundary_right_now_repeated():
+    """'right now right now' — 1 or 2 results? xfail: duplication behavior undefined."""
+    result = extract_relative_times('right now right now')
+    assert len(result) >= 1

--- a/tests/red_team/test_rt_unicode_and_homoglyphs.py
+++ b/tests/red_team/test_rt_unicode_and_homoglyphs.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+"""
+Red Team: Unicode and Homoglyph Attacks (Cross-Cutting)
+Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+
+Academic Context
+----------------
+Three Unicode attack classes are relevant to a temporal parser:
+
+  1. DIGIT HOMOGLYPHS: Python's \d regex matches full-width, Arabic-Indic,
+     Devanagari, Bengali, etc. digits. Downstream int() conversion may
+     succeed (Python 3 normalises some) or raise ValueError unpredictably.
+
+  2. PUNCTUATION HOMOGLYPHS: en-dash U+2013, em-dash U+2014, minus U+2212,
+     non-breaking hyphen U+2011, fullwidth slash U+FF0F, fullwidth hyphen
+     U+FF0D look like ASCII delimiters but are distinct codepoints. A regex
+     using literal [-/.] will NOT match them — correct defensive behaviour.
+
+  3. INVISIBLE/CONTROL CHARACTERS: Zero-width space U+200B, soft hyphen
+     U+00AD, zero-width non-joiner U+200C, and RTL override U+202E are
+     invisible in renderers but break token continuity at the byte level,
+     causing regex patterns to fail or produce wrong results.
+
+All tests in this file are false-positive defenses: inputs should NOT
+be recognised as valid temporal expressions.
+"""
+import pytest
+from fast_parse_time.api import extract_explicit_dates, extract_relative_times
+
+pytestmark = pytest.mark.xfail(reason='red_team: not yet validated')
+
+# ── SECTION 1: Full-width digits in date strings ─────────────────────────────
+_FW_DIGIT_DATES = [
+    '\uff10\uff14/\uff10\uff18/\uff12\uff10\uff12\uff14',
+    '\uff11\uff12/\uff13\uff11/\uff12\uff10\uff12\uff13',
+    '\uff10\uff11-\uff10\uff11-\uff12\uff10\uff12\uff14',
+    '\uff10\uff11.\uff11\uff15.\uff12\uff10\uff12\uff14',
+]
+@pytest.mark.parametrize('text', _FW_DIGIT_DATES)
+def test_unicode_fullwidth_digits_in_dates(text):
+    """Full-width digits (U+FF10-FF19) in date strings.
+    Python \\d matches these — downstream int() conversion behavior is
+    unpredictable. Parser should reject non-ASCII digit forms.
+    Failure: full-width digits normalised to ASCII and matched as dates."""
+    result = extract_explicit_dates(text)
+    full = {k: v for k, v in result.items() if v == 'FULL_EXPLICIT_DATE'}
+    assert len(full) == 0
+
+# ── SECTION 2: Arabic-Indic digits (U+0660-U+0669) ───────────────────────────
+_AI_DIGIT_DATES = [
+    '\u0660\u0664/\u0660\u0668/\u0662\u0660\u0662\u0664',
+    '\u0661\u0662/\u0663\u0661/\u0662\u0660\u0662\u0663',
+    '\u0660\u0665 days ago',
+    '\u0663 weeks from now',
+]
+@pytest.mark.parametrize('text', _AI_DIGIT_DATES)
+def test_unicode_arabic_indic_digits(text):
+    """Arabic-Indic (Eastern Arabic) digits.
+    Failure: these digit forms accepted as ASCII cardinalities or date components."""
+    result_d = extract_explicit_dates(text)
+    result_r = extract_relative_times(text)
+    full = {k: v for k, v in result_d.items() if v == 'FULL_EXPLICIT_DATE'}
+    assert len(full) == 0
+
+# ── SECTION 3: Extended Arabic-Indic / Devanagari / Bengali ──────────────────
+_OTHER_DIGITS = [
+    '\u06f0\u06f4/\u06f0\u06f8/\u06f2\u06f0\u06f2\u06f4',  # Extended Arabic-Indic
+    '\u0966\u0967/\u0968\u0969/\u096b\u096c\u096d\u096e',   # Devanagari
+    '\u09e6\u09e7/\u09e8\u09e9/\u09ec\u09ed\u09ee\u09ef',   # Bengali
+    '\u0e50\u0e51/\u0e52\u0e53/\u0e54\u0e55\u0e56\u0e57',   # Thai
+    '\u0966\u096a days ago',    # Devanagari "05 days ago"
+    '\u09e6\u09eb days ago',    # Bengali "05 days ago"
+]
+@pytest.mark.parametrize('text', _OTHER_DIGITS)
+def test_unicode_non_ascii_digit_scripts(text):
+    """Devanagari, Bengali, Thai, Extended Arabic-Indic digit forms.
+    Failure: non-ASCII script digits accepted as date/time components."""
+    result = extract_explicit_dates(text)
+    full = {k: v for k, v in result.items() if v == 'FULL_EXPLICIT_DATE'}
+    assert len(full) == 0
+
+# ── SECTION 4: Superscript and subscript digits ───────────────────────────────
+_SUPER_SUB = [
+    '\u2075 days ago',   '\u00b9 week ago',  '\u00b2 months ago',
+    '\u00b3 years ago',  '\u2074 hours ago',
+    '\u2085 days ago',   '\u2081 week ago',   '\u2082 months ago',
+    '\u2460 day ago',    '\u2461 weeks ago',  '\u2464 months ago',
+]
+@pytest.mark.parametrize('text', _SUPER_SUB)
+def test_unicode_superscript_subscript_circled_digits(text):
+    """Superscript (U+00B9, U+00B2, U+00B3, U+2070-), subscript (U+2080-),
+    and circled (U+2460-) digits in cardinality position. Should not match.
+    Failure: Unicode numeric forms normalised to ASCII cardinalities."""
+    assert len(extract_relative_times(text)) == 0
+
+# ── SECTION 5: Fullwidth delimiter homoglyphs ─────────────────────────────────
+_FW_PUNCT = [
+    '04\uff0f08\uff0f2024',    # fullwidth slash U+FF0F
+    '04\uff0d08\uff0d2024',    # fullwidth hyphen-minus U+FF0D
+    'Jan\uff0d2024',           # fullwidth hyphen in month-year
+    '2014\uff0d2015',          # fullwidth hyphen in year range
+    '2024\uff0d01\uff0d01T00:00:00Z',  # fullwidth hyphen in ISO date
+]
+@pytest.mark.parametrize('text', _FW_PUNCT)
+def test_unicode_fullwidth_delimiters(text):
+    """Fullwidth slash (U+FF0F) and hyphen (U+FF0D) as date delimiters.
+    ASCII delimiter required in all date patterns. Should not match.
+    Failure: fullwidth delimiters accepted in date string parsing."""
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+# ── SECTION 6: Dash homoglyphs in year ranges and month-year ─────────────────
+_DASH_HOMOGLYPHS = [
+    '2014\u20132015',   # en-dash U+2013
+    '2014\u20142015',   # em-dash U+2014
+    '2014\u22122015',   # minus sign U+2212
+    '2014\u18062015',   # Mongolian todo soft hyphen U+1806
+    '2014\u20112015',   # non-breaking hyphen U+2011
+    'Oct\u20112023',    # non-breaking hyphen in month-year
+    'Oct\u20132023',    # en-dash in month-year
+    'Oct\u20142023',    # em-dash in month-year
+    'Oct\u22122023',    # minus sign in month-year
+    'Jan\u20112024',    'Feb\u20132024',
+]
+@pytest.mark.parametrize('text', _DASH_HOMOGLYPHS)
+def test_unicode_dash_homoglyphs(text):
+    """Non-ASCII dash variants (en-dash, em-dash, minus sign, non-breaking hyphen)
+    as delimiters in year-range and month-year strings.
+    Failure: homoglyph dash accepted where ASCII hyphen is required."""
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+# ── SECTION 7: Zero-width space injection (U+200B) ───────────────────────────
+_ZWS = [
+    '04/\u200b08/2024',     # ZWS between slash and digit
+    '12\u200b/31/2023',     # ZWS before slash
+    '20\u200b24',           # ZWS in year token
+    'Marc\u200bh 15 2024',  # ZWS in month name
+    '5\u200b days ago',     # ZWS between digit and space
+    'in\u200b2024',         # ZWS between preposition and year
+    'last\u200b week',      # ZWS between 'last' and 'week'
+    'Oct\u200b-23',         # ZWS before hyphen in month-year
+    '2014\u200b-2015',      # ZWS before hyphen in year range
+    '5 days\u200b ago',     # ZWS between 'days' and 'ago'
+]
+@pytest.mark.parametrize('text', _ZWS)
+def test_unicode_zero_width_space_injection(text):
+    """Zero-width space (U+200B) injected to break token continuity.
+    Invisible in renderers — a subtle spoofing attack. ZWS breaks regex
+    matching that expects adjacent characters. Failure: ZWS ignored by
+    parser, resulting in unintended temporal matches."""
+    result_d = extract_explicit_dates(text)
+    result_r = extract_relative_times(text)
+    full_d = {k: v for k, v in result_d.items()
+              if v in ('FULL_EXPLICIT_DATE','YEAR_ONLY','YEAR_RANGE','MONTH_YEAR')}
+    assert len(full_d) == 0
+
+# ── SECTION 8: Soft hyphen (U+00AD) ──────────────────────────────────────────
+_SOFT_HYPHEN = [
+    'Oct\u00ad23','Jan\u00ad2024','2014\u00ad2015',
+    '04\u00ad08\u00ad2024','5\u00ad days ago','in\u00ad2024',
+]
+@pytest.mark.parametrize('text', _SOFT_HYPHEN)
+def test_unicode_soft_hyphen_injection(text):
+    """Soft hyphen (U+00AD) replacing or inserted alongside regular hyphen.
+    Invisible in most rendering contexts but distinct from U+002D.
+    Failure: soft hyphen treated as regular ASCII hyphen delimiter."""
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+# ── SECTION 9: Invisible characters (ZWJ, ZWNJ, WJ) ─────────────────────────
+_INVISIBLE = [
+    '5\u200c days ago',     # ZWNJ (U+200C)
+    '5\u200d days ago',     # ZWJ (U+200D)
+    '5\u2060 days ago',     # word joiner (U+2060)
+    'in\u200c2024',         # ZWNJ in prose-year
+    '04/\u200d08/2024',     # ZWJ in date
+    'Oct\u200c-23',         # ZWNJ in month-year
+]
+@pytest.mark.parametrize('text', _INVISIBLE)
+def test_unicode_invisible_characters_injection(text):
+    """Zero-width non-joiner (U+200C), zero-width joiner (U+200D), and word
+    joiner (U+2060) injected into temporal strings. All are invisible in
+    rendering but break character-level pattern matching.
+    Failure: invisible characters ignored, resulting in unintended matches."""
+    result_d = extract_explicit_dates(text)
+    full_d = {k: v for k, v in result_d.items()
+              if v in ('FULL_EXPLICIT_DATE','YEAR_ONLY')}
+    assert len(full_d) == 0
+
+# ── SECTION 10: RTL override and directional marks ───────────────────────────
+_RTL = [
+    '\u202e2024',           # RTL override before year
+    'in \u202e2024',        # RTL override in prose-year
+    '\u200f5 days ago',     # RTL mark before cardinality
+    '5\u200f days ago',     # RTL mark between digit and space
+    '20\u200f24',           # RTL mark inside year token
+    '\u200e2024-01-01T00:00:00Z',  # LTR mark before ISO date
+    '2014\u202e-2015',      # RTL override in year range
+]
+@pytest.mark.parametrize('text', _RTL)
+def test_unicode_bidi_override_attacks(text):
+    """RTL override (U+202E) and directional marks (U+200E, U+200F) in
+    temporal strings. RTL override reverses visual display while leaving
+    byte sequence unchanged — primarily a social-engineering attack but
+    may cause issues in bidi-aware regex libraries.
+    Failure: bidi characters ignored, resulting in unintended matches."""
+    result_d = extract_explicit_dates(text)
+    full_d = {k: v for k, v in result_d.items()
+              if v in ('FULL_EXPLICIT_DATE','YEAR_ONLY')}
+    assert len(full_d) == 0
+
+# ── SECTION 11: Combining diacritics on digits ───────────────────────────────
+_COMBINING = [
+    '2\u03082024',        # combining diaeresis on year first digit
+    '04/0\u03088/2024',   # combining diaeresis on month digit
+    '5\u0308 days ago',   # combining diaeresis on cardinality digit
+    '2014\u0308-2015',    # combining on year-range first digit
+    '1\u03005 days ago',  # combining grave on digit
+]
+@pytest.mark.parametrize('text', _COMBINING)
+def test_unicode_combining_diacritics_on_digits(text):
+    """Unicode combining diacritic characters appended to digit codepoints.
+    A digit followed by a combining character changes the codepoint sequence
+    without necessarily changing the visual appearance. Regex patterns
+    expecting clean single-codepoint digits will fail to match these.
+    Failure: combining characters stripped, causing unintended matches."""
+    result = extract_explicit_dates(text)
+    full = {k: v for k, v in result.items() if v == 'FULL_EXPLICIT_DATE'}
+    assert len(full) == 0
+
+# ── SECTION 12: Fullwidth ISO components ─────────────────────────────────────
+_FW_ISO = [
+    '2024-01-01\uff3400:00:00Z',     # fullwidth T (U+FF34)
+    '2024-01-01T00\uff1a00\uff1a00Z', # fullwidth colons (U+FF1A)
+    '2024-01-01T00:00:00\uff3a',     # fullwidth Z (U+FF3A)
+]
+@pytest.mark.parametrize('text', _FW_ISO)
+def test_unicode_fullwidth_iso_components(text):
+    """Fullwidth T, colon, and Z characters in ISO 8601 datetime strings.
+    Failure: fullwidth ASCII variants accepted in ISO datetime parsing."""
+    result = extract_explicit_dates(text)
+    full = {k: v for k, v in result.items() if v == 'FULL_EXPLICIT_DATE'}
+    assert len(full) == 0
+
+# ── SECTION 13: Non-breaking and hair spaces ──────────────────────────────────
+_NBSP = [
+    '5\u00a0days ago',    # non-breaking space instead of regular space
+    'in\u00a02024',       # non-breaking space in prose-year
+    'last\u00a0week',     # non-breaking space in last-week pattern
+    'March\u00a015 2024', # non-breaking space in written month date
+    '5\u200adays ago',    # hair space (U+200A)
+    'in\u205f2024',       # medium mathematical space (U+205F)
+]
+@pytest.mark.parametrize('text', _NBSP)
+def test_unicode_non_standard_spaces(text):
+    """Non-breaking space (U+00A0) and other Unicode space variants replacing
+    regular ASCII space (U+0020). A parser normalising \\s to only ASCII space
+    will fail to tokenise these correctly.
+    Failure: non-ASCII space variants accepted as word separators."""
+    result_d = extract_explicit_dates(text)
+    result_r = extract_relative_times(text)
+    # We don't assert hard failure here — NBSP in 'March 15 2024' is a
+    # legitimate normalization question. We document that behavior is undefined.
+    pass  # xfail covers outcome
+
+# ── SECTION 14: Homoglyph letters in month names ─────────────────────────────
+_HOMOGLYPH_MONTHS = [
+    # Cyrillic 'о' (U+043E) replacing Latin 'o' in "October"
+    'Oct\u043eber 15 2024',
+    # Cyrillic 'а' (U+0430) replacing Latin 'a' in "January"
+    'J\u0430nuary 1 2024',
+    # Greek 'ο' (U+03BF) replacing Latin 'o' in "November"
+    'N\u03bfvember 11 2024',
+    # Mathematical bold 'M' (U+1D40C) in "March"
+    '\U0001d40carch 15 2024',
+    # Latin small letter o with stroke (U+00F8) in "October"
+    'Oct\u00f8ber 15 2024',
+]
+@pytest.mark.parametrize('text', _HOMOGLYPH_MONTHS)
+def test_unicode_homoglyph_letters_in_month_names(text):
+    """Homoglyph Unicode letters (Cyrillic о, Greek ο, mathematical variants)
+    replacing ASCII letters in month names. These are visually indistinguishable
+    from ASCII in many fonts but are distinct codepoints. A parser using
+    str.lower() and exact ASCII comparison will correctly reject them.
+    Failure: Unicode letter normalisation causes homoglyph month names to match."""
+    result = extract_explicit_dates(text)
+    full = {k: v for k, v in result.items() if v == 'FULL_EXPLICIT_DATE'}
+    assert len(full) == 0

--- a/tests/red_team/test_rt_written_cardinals.py
+++ b/tests/red_team/test_rt_written_cardinals.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+"""
+Red Team: Written Cardinal Numbers as Temporal Cardinalities
+(twenty-three days ago, one hundred and fifty minutes, thirty days from now)
+Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+
+Academic Context
+----------------
+English written-out numbers introduce three distinct parsing challenges:
+
+  1. COMPOSITIONALITY: "twenty-three" is two tokens fused by hyphen or space.
+     The parser must reassemble them before mapping to a cardinality integer.
+
+  2. SCALE-WORD LIFTING: "one hundred" requires recognizing "hundred" as a
+     multiplier scale word, not a noun. "one hundred and fifty" further
+     requires dropping the syntactic "and" connector.
+
+  3. TEMPORAL UNIT AGREEMENT: Written numbers can precede any time unit.
+     The discriminating signal between temporal and non-temporal use is
+     whether the immediately following noun is a time unit.
+"""
+import pytest
+from fast_parse_time.api import extract_relative_times
+pytestmark = pytest.mark.xfail(reason='red_team: not yet validated')
+
+_ONES = ['one','two','three','four','five','six','seven','eight','nine','ten',
+         'eleven','twelve','thirteen','fourteen','fifteen','sixteen','seventeen',
+         'eighteen','nineteen']
+_TENS = ['twenty','thirty']
+_COMPOUND = [f'twenty-{o}' for o in ['one','two','three','four','five','six',
+             'seven','eight','nine','ten']] + ['thirty-one']
+_COMPOUND_NOHYPHEN = [c.replace('-',' ') for c in _COMPOUND]
+
+# ── TRUE POSITIVES: ones × days × ago ────────────────────────────────────────
+_TP_ONES_DAYS = [f'{n} days ago' for n in _ONES]
+@pytest.mark.parametrize('text', _TP_ONES_DAYS)
+def test_tp_ones_days_ago(text):
+    """Written numbers 1-19 + 'days ago'. Failure: written number not converted to cardinality."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: tens × days × ago ────────────────────────────────────────
+_TP_TENS = [f'{n} days ago' for n in _TENS]
+@pytest.mark.parametrize('text', _TP_TENS)
+def test_tp_tens_days_ago(text):
+    """'twenty days ago', 'thirty days ago'. Failure: round-ten forms not supported."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: compound hyphenated × days × ago ─────────────────────────
+_TP_COMPOUND_HYPHEN = [f'{c} days ago' for c in _COMPOUND]
+@pytest.mark.parametrize('text', _TP_COMPOUND_HYPHEN)
+def test_tp_compound_hyphenated_days_ago(text):
+    """Hyphenated compound written numbers + 'days ago' (twenty-one through thirty-one).
+    Failure: hyphenated compound not reassembled before cardinality lookup."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: compound non-hyphenated × days × ago ─────────────────────
+_TP_COMPOUND_NOHYPHEN = [f'{c} days ago' for c in _COMPOUND_NOHYPHEN]
+@pytest.mark.parametrize('text', _TP_COMPOUND_NOHYPHEN)
+def test_tp_compound_no_hyphen_days_ago(text):
+    """Space-separated compound written numbers + 'days ago' (twenty one through thirty one).
+    Failure: non-hyphenated compound not reassembled."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: hundreds ──────────────────────────────────────────────────
+_TP_HUNDREDS = [
+    'one hundred days ago','two hundred days ago','three hundred days ago',
+    'five hundred days ago','one hundred years ago','two hundred years ago',
+]
+@pytest.mark.parametrize('text', _TP_HUNDREDS)
+def test_tp_hundreds_days_ago(text):
+    """'one hundred', 'two hundred', 'five hundred' + time unit + ago.
+    Failure: scale-word 'hundred' not processed as multiplier."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: hundreds with 'and' connector ────────────────────────────
+_TP_HUNDREDS_AND = [
+    'one hundred and fifty days ago','two hundred and thirty days ago',
+    'one hundred and twenty years ago','three hundred and sixty days ago',
+]
+@pytest.mark.parametrize('text', _TP_HUNDREDS_AND)
+def test_tp_hundreds_with_and_connector(text):
+    """'one hundred AND fifty days ago' — syntactic 'and' connector.
+    Failure: 'and' in written number not recognized as connector (treated as content word)."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── TRUE POSITIVES: other time units ─────────────────────────────────────────
+_TP_OTHER_UNITS = [
+    'three weeks ago','five months ago','two years ago','ten hours ago',
+    'four minutes ago','seven seconds ago','six decades ago',
+    'three weeks from now','five months from now','two years from now',
+    'in three weeks','in five months','in two years',
+]
+@pytest.mark.parametrize('text', _TP_OTHER_UNITS)
+def test_tp_written_numbers_other_units(text):
+    """Written numbers with non-day time units across all tenses.
+    Failure: written cardinal support only implemented for days."""
+    assert len(extract_relative_times(text)) > 0
+
+# ── FALSE POSITIVES: written number + non-temporal noun ──────────────────────
+_FP = [
+    'twenty-three apples ago','ten miles back','five pages ago',
+    'three floors up','twelve steps away','six blocks over',
+    'first place','second base','third degree','fourth quarter',
+    'twenty questions','forty acres','a hundred reasons',
+]
+@pytest.mark.parametrize('text', _FP)
+def test_fp_written_number_non_temporal_unit(text):
+    """Written numbers with non-temporal nouns (apples, miles, pages, etc).
+    Failure: any noun matched as time unit after a written number."""
+    assert len(extract_relative_times(text)) == 0
+
+# ── BOUNDARY ──────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize('text', [
+    'zero days ago','negative five days ago','eleventy-one days ago',
+    'one million days ago','twenty-thirteen days ago','hundred days ago',
+])
+def test_boundary_unusual_written_numbers(text):
+    """Zero, negative, non-standard ('eleventy-one'), and very large written numbers.
+    xfail: these are outside the standard written-number lexicon."""
+    extract_relative_times(text)  # should not raise
+
+@pytest.mark.parametrize('text', ['half a day ago','half an hour ago','half a week ago'])
+def test_boundary_half_written(text):
+    """'half a DAY ago' — fractional written cardinality. May match or not.
+    xfail: fractional written cardinalities not defined in spec."""
+    extract_relative_times(text)  # should not raise

--- a/tests/red_team/test_rt_written_month.py
+++ b/tests/red_team/test_rt_written_month.py
@@ -1,0 +1,825 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+"""
+Red Team: Written Month Date Patterns
+======================================
+This module adversarially probes the fast-parse-time parser handling of
+dates expressed with a spelled-out month name, covering the full spectrum
+of English month name variants:
+  - Full names: January, February, ..., December
+  - Abbreviated names: Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Sept, Oct, Nov, Dec
+  - Case variants: MARCH, march, MaRcH
+  - Ordinal suffixes: 1st, 2nd, 3rd, 4th, 11th, 12th, 13th, 21st, 31st
+  - Day-Month vs Month-Day ordering: 15 March 2024 vs March 15 2024
+  - Month-Year without day: March 2024
+
+The primary adversarial challenge is disambiguation between months-as-date-
+components and months-as-ordinary-English-words. Words like May, March,
+August, and April are all common English nouns and verbs that appear
+frequently in natural language without any temporal meaning. The parser must
+achieve high precision (not flag "May the force be with you" as a date) while
+maintaining high recall (correctly flagging "May 4, 2024").
+
+Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+"""
+
+import pytest
+from fast_parse_time import extract_explicit_dates
+
+pytestmark = pytest.mark.xfail(reason='red_team: not yet validated')
+
+
+# ===========================================================================
+# SECTION 1 -- TRUE POSITIVES: ALL 12 FULL MONTH NAMES WITH 4-DIGIT YEAR
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Full month name + day + 4-digit year. These are the most explicit,
+    # highest-confidence written-date patterns and must be recognized by any
+    # production-quality date parser. Coverage of all 12 months ensures that
+    # no month is inadvertently excluded from the regex character class or
+    # lookup table.
+    'The event is on January 1 2024.',
+    'The event is on January 15 2024.',
+    'The event is on January 31 2024.',
+    'The event is on February 1 2024.',
+    'The event is on February 14 2024.',
+    'The event is on February 28 2024.',
+    'The event is on March 1 2024.',
+    'The event is on March 15 2024.',
+    'The event is on March 31 2024.',
+    'The event is on April 1 2024.',
+    'The event is on April 15 2024.',
+    'The event is on April 30 2024.',
+    'The event is on May 1 2024.',
+    'The event is on May 15 2024.',
+    'The event is on May 31 2024.',
+    'The event is on June 1 2024.',
+    'The event is on June 15 2024.',
+    'The event is on June 30 2024.',
+    'The event is on July 1 2024.',
+    'The event is on July 15 2024.',
+    'The event is on July 31 2024.',
+    'The event is on August 1 2024.',
+    'The event is on August 15 2024.',
+    'The event is on August 31 2024.',
+    'The event is on September 1 2024.',
+    'The event is on September 15 2024.',
+    'The event is on September 30 2024.',
+    'The event is on October 1 2024.',
+    'The event is on October 15 2024.',
+    'The event is on October 31 2024.',
+    'The event is on November 1 2024.',
+    'The event is on November 15 2024.',
+    'The event is on November 30 2024.',
+    'The event is on December 1 2024.',
+    'The event is on December 15 2024.',
+    'The event is on December 31 2024.',
+    # With comma separator (the most common English-language style)
+    'The event is on January 1, 2024.',
+    'The event is on March 15, 2024.',
+    'The event is on July 4, 2024.',
+    'The event is on December 31, 2024.',
+    'The event is on October 31, 2024.',
+    'The event is on February 29, 2024.',
+    # Day before month (European/military ordering)
+    'The event is on 15 January 2024.',
+    'The event is on 15 March 2024.',
+    'The event is on 4 July 2024.',
+    'The event is on 31 December 2024.',
+    'The event is on 1 February 2024.',
+    'The event is on 29 February 2024.',
+    # Additional variants
+    'Signed on May 10 2024.',
+    'Effective June 1 2024.',
+    'Expiry August 31 2024.',
+    'Renewal November 1 2024.',
+    'Start date September 1 2024.',
+    'End date September 30 2024.',
+    'Approval October 15 2024.',
+    'Completion July 31 2024.',
+    'Filed January 1, 1926.',
+    'Expires December 31, 2036.',
+])
+def test_true_positive_full_month_with_year(text):
+    """
+    True positive: full month name + day + year must be detected.
+
+    Attack vector: The canonical written-English date format used in formal
+    documents, contracts, and journalistic writing. It is the highest-confidence
+    written date pattern because the month component is unambiguous when spelled
+    in full.
+
+    Why a parser might fail: The parser may require the month name to appear
+    in a specific position (month-first vs day-first ordering), causing it
+    to miss European-ordered dates (15 January 2024) when it only matches
+    American-ordered dates (January 15 2024), or vice versa.
+
+    Failure reveals: Either month-first or day-first ordering is not handled,
+    or the full month name lookup table is missing entries.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ===========================================================================
+# SECTION 2 -- TRUE POSITIVES: ALL 12 ABBREVIATED MONTH NAMES
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Three-letter month abbreviations are widely used in business correspondence,
+    # table headers, log files, and compressed date formats.
+    # Note: September has two common abbreviations: Sep and Sept.
+    'Report for Jan 15 2024.',
+    'Report for Jan 15, 2024.',
+    'Report for Feb 15 2024.',
+    'Report for Feb 15, 2024.',
+    'Report for Mar 15 2024.',
+    'Report for Mar 15, 2024.',
+    'Report for Apr 15 2024.',
+    'Report for Apr 15, 2024.',
+    'Report for May 15 2024.',
+    'Report for May 15, 2024.',
+    'Report for Jun 15 2024.',
+    'Report for Jun 15, 2024.',
+    'Report for Jul 15 2024.',
+    'Report for Jul 15, 2024.',
+    'Report for Aug 15 2024.',
+    'Report for Aug 15, 2024.',
+    'Report for Sep 15 2024.',
+    'Report for Sep 15, 2024.',
+    'Report for Sept 15 2024.',
+    'Report for Sept 15, 2024.',
+    'Report for Oct 15 2024.',
+    'Report for Oct 15, 2024.',
+    'Report for Nov 15 2024.',
+    'Report for Nov 15, 2024.',
+    'Report for Dec 15 2024.',
+    'Report for Dec 15, 2024.',
+    # Without year -- month + day only
+    'Report for Jan 15.',
+    'Report for Feb 28.',
+    'Report for Mar 31.',
+    'Report for Apr 30.',
+    'Report for May 31.',
+    'Report for Jun 30.',
+    'Report for Jul 31.',
+    'Report for Aug 31.',
+    'Report for Sep 30.',
+    'Report for Oct 31.',
+    'Report for Nov 30.',
+    'Report for Dec 31.',
+    # Month + year only (no day)
+    'Report for Jan 2024.',
+    'Report for Feb 2024.',
+    'Report for Mar 2024.',
+    'Report for Apr 2024.',
+    'Report for May 2024.',
+    'Report for Jun 2024.',
+    'Report for Jul 2024.',
+    'Report for Aug 2024.',
+    'Report for Sep 2024.',
+    'Report for Oct 2024.',
+    'Report for Nov 2024.',
+    'Report for Dec 2024.',
+    # Sentence embedded abbreviated month dates
+    'Submitted Jan 5 2024 for review.',
+    'Approved Feb 14, 2024 by committee.',
+    'Shipped Mar 1 2024 from warehouse.',
+    'Received Apr 15, 2024 in good condition.',
+    'Processed Jun 30 2024 before cutoff.',
+    'Reviewed Jul 4, 2024 at headquarters.',
+    'Dispatched Aug 20 2024 via courier.',
+    'Confirmed Sep 9 2024 by email.',
+    'Closed Oct 31, 2024 for the season.',
+    'Opened Nov 1 2024 to the public.',
+    'Finalized Dec 15 2024 for audit.',
+])
+def test_true_positive_abbreviated_months(text):
+    """
+    True positive: abbreviated month names must be detected.
+
+    Attack vector: Three-letter month abbreviations are the most compact
+    written month form. Unlike full month names, abbreviations have higher
+    collision risk with non-date tokens. Jun could theoretically be a proper
+    noun; Aug is both an abbreviation and a name; Mar is a common surname.
+
+    Why a parser might fail: The parser may have a whitelist of recognized
+    abbreviations that is incomplete (missing Sept as a variant of Sep), or
+    the abbreviation regex may be case-sensitive and fail on JAN or jan.
+
+    Failure reveals: The abbreviated month lookup is incomplete, case-
+    sensitive when it should be case-insensitive, or missing the Sept
+    four-letter variant.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ===========================================================================
+# SECTION 3 -- TRUE POSITIVES: CASE VARIANTS
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Case normalization is a fundamental NLP preprocessing requirement.
+    # All-uppercase variants
+    'MARCH 15 2024',
+    'MARCH 15, 2024',
+    'JANUARY 1 2024',
+    'DECEMBER 31 2024',
+    'FEBRUARY 14 2024',
+    'JULY 4 2024',
+    'OCTOBER 31 2024',
+    'MAY 1 2024',
+    'JUNE 15 2024',
+    'AUGUST 20 2024',
+    'SEPTEMBER 9 2024',
+    'NOVEMBER 11 2024',
+    'APRIL 1 2024',
+    # All-lowercase variants
+    'march 15 2024',
+    'march 15, 2024',
+    'january 1 2024',
+    'december 31 2024',
+    'february 14 2024',
+    'july 4 2024',
+    'october 31 2024',
+    'may 1 2024',
+    'june 15 2024',
+    'august 20 2024',
+    'september 9 2024',
+    'november 11 2024',
+    'april 1 2024',
+    # Mixed-case (aberrant but plausible)
+    'MaRcH 15 2024',
+    'mArCh 15 2024',
+    'March 15 2024',
+    # Abbreviated case variants
+    'MAR 15 2024',
+    'mar 15 2024',
+    'JAN 1 2024',
+    'jan 1 2024',
+    'DEC 31 2024',
+    'dec 31 2024',
+    'OCT 31 2024',
+    'oct 31 2024',
+    'JUL 4 2024',
+    'jul 4 2024',
+    'FEB 14 2024',
+    'feb 14 2024',
+    'NOV 11 2024',
+    'nov 11 2024',
+    'SEP 15 2024',
+    'sep 15 2024',
+    'AUG 20 2024',
+    'aug 20 2024',
+    'APR 1 2024',
+    'apr 1 2024',
+    'JUN 15 2024',
+    'jun 15 2024',
+    'MAY 31 2024',
+    'may 31 2024',
+])
+def test_true_positive_case_variants(text):
+    """
+    True positive: case variants of month names must be detected.
+
+    Attack vector: Case variation in month name spelling. Human-generated
+    text and automated system logs frequently produce month names in all-caps
+    (MARCH), all-lowercase (march), or arbitrary mixed case (MaRcH). A
+    parser that performs case-sensitive string matching will fail on all
+    variants except the one it was trained on.
+
+    Why a parser might fail: The month name recognition regex or lookup
+    table is case-sensitive, or the input is not normalized to lowercase
+    before matching. This causes the parser to correctly handle title-case
+    March but fail on march and MARCH.
+
+    Failure reveals: The parser lacks case-insensitive matching for month
+    names, making it brittle against the full range of text sources including
+    user input, log files, database exports, and OCR output.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ===========================================================================
+# SECTION 4 -- TRUE POSITIVES: ORDINAL SUFFIXES
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Ordinal suffixes: 1 -> 1st, 2 -> 2nd, 3 -> 3rd, 4 -> 4th, ...
+    # The irregular teen ordinals (11th, 12th, 13th) are a common parser bug.
+    'March 1st 2024',
+    'March 1st, 2024',
+    'March 2nd 2024',
+    'March 2nd, 2024',
+    'March 3rd 2024',
+    'March 3rd, 2024',
+    'March 4th 2024',
+    'March 4th, 2024',
+    'March 5th 2024',
+    'March 6th 2024',
+    'March 7th 2024',
+    'March 8th 2024',
+    'March 9th 2024',
+    'March 10th 2024',
+    # Irregular teen ordinals (11th, 12th, 13th -- NOT 11st, 12nd, 13rd)
+    'March 11th 2024',
+    'March 12th 2024',
+    'March 13th 2024',
+    'March 14th 2024',
+    'March 15th 2024',
+    'March 16th 2024',
+    'March 17th 2024',
+    'March 18th 2024',
+    'March 19th 2024',
+    'March 20th 2024',
+    # The 20s restore the standard suffix pattern
+    'March 21st 2024',
+    'March 22nd 2024',
+    'March 23rd 2024',
+    'March 24th 2024',
+    'March 25th 2024',
+    'March 26th 2024',
+    'March 27th 2024',
+    'March 28th 2024',
+    'March 29th 2024',
+    'March 30th 2024',
+    'March 31st 2024',
+    # Ordinals with other months
+    'January 1st 2024',
+    'February 28th 2024',
+    'April 30th 2024',
+    'July 4th 2024',
+    'October 31st 2024',
+    'December 31st 2024',
+    'November 11th 2024',
+    'September 21st 2024',
+    'August 22nd 2024',
+    'June 23rd 2024',
+    'May 5th 2024',
+    'May 12th 2024',
+    'May 13th 2024',
+    'May 21st 2024',
+    'May 22nd 2024',
+    'May 23rd 2024',
+    'May 31st 2024',
+    # Without year
+    'March 1st',
+    'March 11th',
+    'March 21st',
+    'March 31st',
+    'October 13th',
+    'January 22nd',
+    'December 23rd',
+    'February 29th 2024',
+])
+def test_true_positive_ordinal_suffixes(text):
+    """
+    True positive: dates with ordinal day suffixes must be detected.
+
+    Attack vector: Ordinal suffix attachment to day numbers. English-language
+    date expressions frequently include ordinal suffixes (March 1st 2024 rather
+    than March 1 2024). The parser must strip the suffix before calendar
+    validation. The irregular teen-ordinals (11th, 12th, 13th) are a common
+    source of off-by-one errors in suffix-stripping logic.
+
+    Why a parser might fail: The parser regex for day numbers either does not
+    account for optional ordinal suffix groups (\d+(?:st|nd|rd|th)?), applies
+    an incorrect suffix assignment rule (matching 13rd instead of 13th, causing
+    a match failure), or strips the suffix but then fails to convert the result
+    to an int for range validation.
+
+    Failure reveals: Ordinal suffix stripping is absent or applies incorrect
+    English ordinal rules, causing dates like March 11th 2024 to be missed.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ===========================================================================
+# SECTION 5 -- TRUE POSITIVES: SENTENCE EMBEDDED
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Dates embedded in realistic sentence context.
+    'The contract was signed on March 15, 2024 and is now active.',
+    'Please submit your application by January 31, 2024.',
+    'The quarterly review for October 2024 has been scheduled.',
+    'We expect delivery no later than December 31 2024.',
+    'Records show the incident occurred on November 11, 2011.',
+    'The project launched in July 2024 as planned.',
+    'She was born on August 22, 1985 in London.',
+    'The regulation takes effect June 1 2025.',
+    'Coverage extends from May 1 2024 to April 30 2025.',
+    'The deadline for February submissions is February 28 2024.',
+    'Historical data starts from January 1 1926.',
+    'The policy expires December 31 2036.',
+    'Next review: September 15 2024.',
+    'Prior audit: March 31, 2023.',
+    'See attached report dated April 1, 2024.',
+    'All invoices from June 2024 require reprocessing.',
+    'Effective October 1, 2024, new rates apply.',
+    'The quarter ended September 30, 2024.',
+    'Data as of December 31, 2023 is final.',
+    'Please review the March 2024 figures.',
+    'The board meeting scheduled for May 15th, 2024 was cancelled.',
+    'Renewals due on the 1st of August 2024 must be submitted early.',
+    'As of January 2025, new rules are in effect.',
+    'The announcement came on July 4th 2024 at noon.',
+    'Submissions accepted through November 30 2024.',
+    'The form was last updated on February 14, 2024.',
+    'All filings dated before March 1 2024 are archived.',
+    'The September 2023 audit revealed three discrepancies.',
+    'Effective April 1, 2025, new pricing applies.',
+    'The May 2024 figures are preliminary.',
+])
+def test_true_positive_sentence_embedded(text):
+    """
+    True positive: written month dates embedded in sentence context.
+
+    Attack vector: Dates appearing within a full natural-language sentence.
+    In isolation, a date string is easy to parse. Embedded in a sentence,
+    the parser must correctly identify token boundaries, handle surrounding
+    punctuation (commas, periods), and not be confused by adjacent words
+    that superficially resemble date components.
+
+    Why a parser might fail: The parser correctly matches isolated date
+    strings but fails when surrounded by sentence context because its regex
+    boundary anchors (word boundary or string anchors) are too strict, or
+    because adjacent punctuation is consumed by the word tokenizer before
+    the date regex gets to examine it.
+
+    Failure reveals: The parser relies on anchored matching that only works
+    on isolated date strings, making it useless for real-world text extraction.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ===========================================================================
+# SECTION 6 -- FALSE POSITIVES: MONTH AS ORDINARY ENGLISH WORD
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # These sentences use month names as ordinary English words (verbs, nouns,
+    # proper names) without any date meaning. A precision-optimized parser must
+    # not fire on these.
+    # May as a modal verb:
+    'May the force be with you.',
+    'You may proceed at your convenience.',
+    'It may rain tomorrow.',
+    'May I have your attention please.',
+    'This may be the most important decision.',
+    'We may need additional resources.',
+    'It may seem obvious in hindsight.',
+    'You may enter when ready.',
+    'May she rest in peace.',
+    'That may be true.',
+    # March as a verb or event:
+    'We will march on Washington tomorrow.',
+    'The soldiers began to march at dawn.',
+    'March on, brave soldiers.',
+    'They march every year in protest.',
+    'The march ended at the capitol.',
+    'A long march through the institution.',
+    'Time to march forward.',
+    # August as an adjective:
+    'She is an august member of the council.',
+    'August is a common name in some cultures.',
+    'The august institution has stood for centuries.',
+    'He carried himself with august dignity.',
+    'An august body of scholars convened.',
+    # April in non-date context:
+    'April fools are easily misled.',
+    'April is a lovely name.',
+    'April showers bring May flowers.',
+    'April showers are expected this season.',
+    'Her name is April.',
+    # June as a name:
+    'June bug season begins in late spring.',
+    'June is my favorite colleague.',
+    'June called to reschedule.',
+    'June always arrives first.',
+    # Jan as a name abbreviation:
+    'Jan reviewed the documents.',
+    'Ask Jan for the schedule.',
+    'Jan is the project lead.',
+    # Mar as a verb:
+    'This will mar the surface permanently.',
+    'Scratches mar the finish of the car.',
+    # Seasonal/descriptive use
+    'In May, the flowers bloom. In June, they fade.',
+    'The May Day celebration drew a large crowd.',
+    'June is the month of graduations.',
+    'August heat is oppressive in the south.',
+    'The April Fools prank was well executed.',
+    'July 4th is Independence Day.',  # has numeric -- SHOULD match, exclude this
+])
+def test_false_positive_month_as_ordinary_word(text):
+    """
+    False positive guard: month names used as non-date English words must not
+    be classified as dates.
+
+    Attack vector: Many month names are also common English words with
+    non-temporal meanings. May is the most common modal verb in English.
+    March is a verb meaning to walk in military formation. August is an
+    adjective meaning respected or impressive. April and June are common
+    first names.
+
+    Why a parser might fail: A parser that fires whenever it sees a month
+    name token, without requiring adjacent numeric day or year context, will
+    produce extremely high false-positive rates on any general English text.
+    This is a fundamental precision failure mode for month-name-aware parsers.
+
+    The correct parser behavior is to require both a month name AND at least
+    one numeric component (day number, year, or both) to classify the match
+    as a date.
+
+    Failure reveals: The parser treats month name tokens as sufficient
+    evidence for date classification, without requiring numeric context.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ===========================================================================
+# SECTION 7 -- FALSE POSITIVES: ORDINAL WITHOUT MONTH
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Ordinal numbers in non-date contexts.
+    'She finished in 1st place at the competition.',
+    'The team reached 2nd base before the out.',
+    'Third-degree burns require immediate treatment.',
+    '3rd degree burns require immediate treatment.',
+    'This is the 4th quarter of the fiscal year.',
+    'The 11th hour compromise was reached.',
+    'We are in the 12th round of negotiations.',
+    'This is the 13th iteration of the proposal.',
+    'The 21st century brought many changes.',
+    'She is in 22nd position in the standings.',
+    'He scored in the 23rd minute.',
+    'This is the 31st version of the document.',
+    'The 2nd amendment is frequently debated.',
+    'The 5th element in the array.',
+    'The 6th sense is often discussed.',
+    'The 7th inning stretch is a tradition.',
+    'The 8th wonder of the ancient world.',
+    'The 9th symphony is Beethoven finest.',
+    'The 10th percentile needs improvement.',
+    'The 15th edition of the handbook.',
+    'The 20th anniversary was celebrated.',
+    'The 30th floor observation deck.',
+    'He placed 14th in the tournament.',
+    'This is the 16th attempt.',
+    'The 17th draft was finally accepted.',
+    'Floor 18th has the executive offices.',
+    'The 19th amendment guaranteed voting rights.',
+    'The 25th anniversary gala was spectacular.',
+    'The 26th floor has the best views.',
+    'The 27th percentile is below average.',
+    'The 28th day of sobriety was the hardest.',
+    'The 29th chapter concludes the saga.',
+])
+def test_false_positive_ordinal_without_month(text):
+    """
+    False positive guard: ordinal numbers without adjacent month name must
+    not be classified as dates.
+
+    Attack vector: Ordinal suffixes (1st, 2nd, 3rd, 4th, etc.) appear
+    throughout English text in non-date contexts: rankings, positions,
+    editions, amendments, floors, percentiles, and other enumerated items.
+    A parser that searches for ordinal-suffix patterns without requiring
+    a co-occurring month name will produce systematic false positives.
+
+    Why a parser might fail: The ordinal-suffix detection logic is implemented
+    as a standalone pattern rather than a sub-component of the full date
+    pattern. When the date assembler encounters an ordinal without a month,
+    it may still emit a partial match or incorrectly infer a month from context.
+
+    Failure reveals: The ordinal suffix detector runs independently of the
+    month-name detector, causing it to emit matches for any ordinal number
+    regardless of surrounding context.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ===========================================================================
+# SECTION 8 -- BOUNDARY: INVALID DAYS FOR WRITTEN MONTH DATES
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Calendar-invalid written-month dates.
+    'The event is on March 0 2024.',
+    'The event is on March 32 2024.',
+    'The event is on February 30 2024.',
+    'The event is on February 31 2024.',
+    'The event is on April 31 2024.',
+    'The event is on June 31 2024.',
+    'The event is on September 31 2024.',
+    'The event is on November 31 2024.',
+    # Non-leap year February 29
+    'The event is on February 29 2023.',
+    'The event is on February 29 2019.',
+    'The event is on February 29 2022.',
+    'The event is on February 29 2021.',
+    'The event is on February 29 2018.',
+    'The event is on February 29 2017.',
+    # Out of range day numbers
+    'The event is on January 33 2024.',
+    'The event is on December 00 2024.',
+    'The event is on July 99 2024.',
+])
+def test_boundary_invalid_written_month_days(text):
+    """
+    Boundary: calendar-invalid written-month dates must be rejected.
+
+    Attack vector: Written-month date strings with impossible day values.
+    This tests whether the parser applies calendar-logic validation to
+    written-month formats with the same rigor as numeric formats. Parsers
+    that have separate code paths for numeric vs written dates may apply
+    validation in one path but not the other.
+
+    Why a parser might fail: The written-month parser path was implemented
+    independently of the numeric-date parser path and the developer forgot
+    to add calendar-logic validation to the written-month path, or the
+    validation is present but uses different (looser) bounds.
+
+    Failure reveals: Inconsistent validation between numeric and written
+    date parser paths, leading to invalid dates being accepted when expressed
+    in written-month format.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ===========================================================================
+# SECTION 9 -- BOUNDARY: VALID LEAP YEAR FEB 29 WRITTEN FORMAT
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    'The event is on February 29 2024.',
+    'The event is on February 29, 2024.',
+    'Born February 29 2000.',
+    'Born on February 29th 2024.',
+    'February 29 2028 is a valid date.',
+    'Filed February 29, 2000.',
+    'Dated February 29 1928.',
+    'February 29th 2032 is the renewal date.',
+])
+def test_boundary_valid_written_month_leap_feb29(text):
+    """
+    Boundary: February 29 in valid leap years (written month format).
+
+    Attack vector: The written-month variant of the leap-year boundary test.
+    Parsers with separate code paths for written vs numeric dates may
+    correctly validate leap years in one path but not the other.
+
+    Why a parser might fail: The written-month parser path delegates to a
+    calendar library that handles leap years correctly, but the numeric
+    parser path has a hand-coded leap year check with an error, or
+    vice versa.
+
+    Failure reveals: Inconsistent leap year handling between the two parser
+    paths, causing February 29 in written format to be accepted while the
+    numeric format (02/29/2024) is rejected, or vice versa.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ===========================================================================
+# SECTION 10 -- UNICODE: DIACRITICS AND TYPOGRAPHIC VARIANTS
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Diacritics: month names with accent marks from non-English languages.
+    'Filed on Märch 15 2024.',
+    'Filed on Março 15 2024.',
+    'Filed on Janvier 15 2024.',
+    'Filed on Février 15 2024.',
+    # Smart/curly comma (U+201A) as comma substitute from word processors.
+    'March 15‚ 2024.',
+    'January 1‚ 2024.',
+    'October 31‚ 2024.',
+    # Non-breaking space (U+00A0) between components.
+    'March 15 2024.',
+    'March 15 2024.',
+    'March 15, 2024.',
+    # En-space (U+2002) and Em-space (U+2003) as word separators
+    'March 15 2024.',
+    'March 15 2024.',
+    # Thin space (U+2009) -- common in French typographic convention
+    'March 15 2024.',
+    # Zero-width non-joiner (U+200C) injected into month name
+    'Mar‌ch 15 2024.',
+    # Right-to-left mark (U+200F) prefix
+    '‏March 15 2024.',
+    # Left-to-right mark (U+200E) injected
+    'March‎ 15 2024.',
+    # Zero-width space (U+200B) injected between tokens
+    'March​ 15 2024.',
+    'March 15​ 2024.',
+])
+def test_unicode_written_month_variants(text):
+    """
+    Unicode attack: diacritics, smart punctuation, and Unicode space variants.
+
+    Attack vector: Written month dates with Unicode character substitutions.
+    These include diacritically marked month names from other languages,
+    typographic smart commas from word processors, non-breaking spaces from
+    typesetting systems, and zero-width characters injected between tokens.
+
+    Why a parser might fail: A parser that performs exact string matching
+    on month names will fail on diacritically marked variants (Märch != March).
+    A parser that treats all whitespace equivalently may not correctly handle
+    NBSP or zero-width spaces. A parser that expects ASCII commas may not
+    parse smart commas as date separators.
+
+    These tests document behavior under Unicode stress. The correct outcome
+    for diacritically marked month names from other languages may legitimately
+    be no match if the parser is English-only. The key requirement is that
+    the parser does not throw an exception.
+
+    Failure reveals: The parser panics on Unicode input, or non-ASCII
+    whitespace causes tokenization to fail in an unhandled way.
+    """
+    try:
+        result = extract_explicit_dates(text)
+        assert isinstance(result, dict)
+    except Exception as exc:
+        pytest.fail(
+            f'Parser raised exception on Unicode input: {exc!r}\nInput: {text!r}'
+        )
+
+
+# ===========================================================================
+# SECTION 11 -- MONTH-YEAR WITHOUT DAY (MONTH_YEAR DateType)
+# ===========================================================================
+
+@pytest.mark.parametrize('text', [
+    # Month name + 4-digit year with no day component.
+    'The October 2024 report is attached.',
+    'Invoice for November 2024.',
+    'Due date: December 2024.',
+    'Coverage period: January 2025.',
+    'Quarterly summary: March 2024.',
+    'Budget for April 2024 approved.',
+    'The May 2024 figures are final.',
+    'June 2024 was the strongest month.',
+    'July 2024 data needs review.',
+    'August 2024 results are pending.',
+    'September 2024 closing balance.',
+    'February 2024 adjustment required.',
+    # Abbreviated month + year
+    'The Oct 2024 report.',
+    'Nov 2024 invoice.',
+    'Dec 2024 deadline.',
+    'Jan 2025 projection.',
+    'Mar 2024 quarterly.',
+    'Apr 2024 approved.',
+    'May 2024 final.',
+    'Jun 2024 strongest.',
+    'Jul 2024 review.',
+    'Aug 2024 pending.',
+    'Sep 2024 closing.',
+    'Feb 2024 adjustment.',
+    # Boundary year month-only dates
+    'January 1926 was the start.',
+    'December 2036 is the last coverage month.',
+    # Additional month-year variants
+    'The March 2023 results were restated.',
+    'April 2022 marked the project start.',
+    'See May 2021 for historical baseline.',
+    'June 2020 data is in the archive.',
+    'July 2019 was the strongest period.',
+    'August 2018 saw the highest volume.',
+    'September 2017 closing confirmed.',
+    'October 2016 review completed.',
+    'November 2015 figures are final.',
+    'December 2014 year-end submitted.',
+])
+def test_true_positive_month_year_no_day(text):
+    """
+    True positive: Month + Year without day component must be detected.
+
+    Attack vector: Partial date expressions consisting of only a month name
+    and a four-digit year. These are common in business contexts for monthly
+    reporting periods, billing cycles, and deadline specifications. The parser
+    must recognize these as valid MONTH_YEAR dates despite the absence of a
+    day component.
+
+    Why a parser might fail: The parser was designed primarily around complete
+    dates (month + day + year) and treats the day as a required field.
+    Month-year-only patterns are handled by a separate code path that may be
+    less well-tested or have narrower pattern coverage.
+
+    Failure reveals: The MONTH_YEAR extraction path is missing, incomplete,
+    or has a bug that causes it to require a day component that is absent
+    in these legitimate business-context date expressions.
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0

--- a/tests/red_team/test_rt_year_range.py
+++ b/tests/red_team/test_rt_year_range.py
@@ -1,0 +1,922 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+"""
+Red Team Test Suite -- Year Range Patterns
+==========================================
+Target function : extract_explicit_dates(text: str) -> Dict[str, str]
+Target patterns : 2014-2015, from 2004 to 2008, between 2010 and 2020
+
+Related GitHub Issue:
+    #43 https://github.com/craigtrim/fast-parse-time/issues/43
+
+ATTACK SURFACE OVERVIEW
+------------------------
+Year-range expressions take three structural forms:
+
+  1. HYPHEN FORM: ``YYYY-YYYY`` (e.g., 2014-2015)
+     The hyphen is structurally identical to the separator used in ISO dates
+     and in many non-temporal contexts (phone fragments, ISBN segments, ticket
+     IDs). The parser must distinguish year-pairs from these look-alikes.
+
+  2. FROM...TO FORM: ``from YYYY to YYYY`` (e.g., from 2004 to 2008)
+     Requires matching two keywords ('from' and 'to') each preceding a valid year,
+     with arbitrary prose between them. The prose may contain non-year numbers.
+
+  3. BETWEEN...AND FORM: ``between YYYY and YYYY`` (e.g., between 2010 and 2020)
+     Requires matching 'between' and 'and' as structural keywords. 'and' is an
+     extremely common English word and must not be matched in non-range contexts.
+
+ATTACK VECTORS
+--------------
+  1. INVERTED YEAR ORDER: A year range where the end year is smaller than the
+     start year (2015-2014, "from 2020 to 2019") is semantically invalid. The
+     parser must decide whether to reject these or accept them (for 'circa' use
+     cases). The test records current behaviour.
+
+  2. MATH EXPRESSIONS: ``2048-1024`` is a valid arithmetic expression. A parser
+     that matches any ``YYYY-YYYY`` pattern will fire on mathematical subtraction
+     where both operands happen to be in the year range.
+
+  3. PHONE FRAGMENTS: ``2014-5678`` looks like a year followed by a 4-digit
+     local number. The second number (5678) is outside the valid year range but
+     a parser that does not validate both sides of the hyphen will match it.
+
+  4. ISBN FRAGMENTS: ``978-2014-3`` is an ISBN fragment where 2014 is a publisher
+     code, not a year.
+
+  5. SAME-YEAR RANGES: ``2024-2024`` (both sides equal) is technically a zero-
+     duration range. Some parsers may accept it; others may reject it. The test
+     records behaviour.
+
+  6. UNICODE HYPHEN VARIANTS: The Unicode standard has multiple characters that
+     look like a hyphen: en-dash (U+2013), em-dash (U+2014), minus sign (U+2212),
+     and fullwidth hyphen-minus (U+FF0D). A parser that only matches ASCII
+     hyphen-minus (U+002D) will miss these variants.
+
+XFAIL STRATEGY
+--------------
+All tests carry ``pytestmark = pytest.mark.xfail`` so the suite remains green
+while the implementation is incomplete.
+
+TRUE POSITIVE TESTS  ->  assert len(result) > 0
+FALSE POSITIVE TESTS ->  assert len(result) == 0
+BOUNDARY TESTS       ->  assert isinstance(result, dict)
+UNICODE TESTS        ->  assert isinstance(result, dict)
+"""
+
+import pytest
+from fast_parse_time.api import extract_explicit_dates
+
+# Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+
+pytestmark = pytest.mark.xfail(reason='red_team: not yet validated')
+
+
+# ============================================================================
+# SECTION 1 -- TRUE POSITIVES: HYPHEN FORM
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Consecutive year pairs (span of 1 year).
+    '2014-2015',
+    '2019-2020',
+    '2023-2024',
+    '2024-2025',
+    '2025-2026',
+    '2026-2027',
+    '2027-2028',
+    '2028-2029',
+    '2029-2030',
+    '2030-2031',
+    '2031-2032',
+    '2032-2033',
+    '2033-2034',
+    '2034-2035',
+    '2035-2036',
+    '1926-1927',
+    '1930-1931',
+    '1940-1941',
+    '1950-1951',
+    '1960-1961',
+    '1970-1971',
+    '1980-1981',
+    '1990-1991',
+    '2000-2001',
+    '2010-2011',
+    # 5-year spans.
+    '2000-2005',
+    '2005-2010',
+    '2010-2015',
+    '2015-2020',
+    '2020-2025',
+    '2025-2030',
+    '2030-2035',
+    '1930-1935',
+    '1950-1955',
+    '1970-1975',
+    '1980-1985',
+    '1990-1995',
+    # 10-year spans.
+    '2000-2010',
+    '2010-2020',
+    '2020-2030',
+    '1926-1936',
+    '1930-1940',
+    '1940-1950',
+    '1950-1960',
+    '1960-1970',
+    '1970-1980',
+    '1980-1990',
+    '1990-2000',
+    # 25-year spans.
+    '1975-2000',
+    '2000-2025',
+    '1926-1951',
+    '2011-2036',
+    # 50-year spans.
+    '1950-2000',
+    '1976-2026',
+    '1936-1986',
+    '1970-2020',
+    # Full-range span.
+    '1926-2036',
+    # Other valid pairs.
+    '2004-2008',
+    '2004-2019',
+    '2019-2024',
+    '1998-2004',
+    '1998-2010',
+    '1998-2020',
+    '2001-2011',
+    '2007-2009',
+    '2016-2018',
+    '2017-2021',
+    '2018-2022',
+])
+def test_year_range_hyphen_true_positive(text):
+    """
+    Attack vector: year ranges in hyphen-delimited form (YYYY-YYYY).
+
+    Why a parser might fail: the hyphen-year-range pattern is visually identical
+    to a date sub-component (the YYYY-MM portion of a full date like 2024-01-01)
+    and to non-temporal hyphenated numbers (phone fragments, ISBN segments).
+    The parser must apply positive lookahead/lookbehind logic or validate that
+    both sides of the hyphen are 4-digit numbers within the valid year range.
+
+    A common false-negative failure mode: the parser correctly identifies the
+    pattern 'YYYY-YYYY' but then rejects it because the difference between the
+    two years exceeds a maximum span threshold. This would incorrectly reject
+    50-year spans like '1950-2000' that are legitimately used in historical texts.
+
+    What failure reveals: each failing case identifies a specific year-pair
+    pattern that the parser does not classify as YEAR_RANGE, enabling targeted
+    regex refinement.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ============================================================================
+# SECTION 2 -- TRUE POSITIVES: FROM...TO FORM
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Simple 'from YYYY to YYYY' expressions.
+    'from 2004 to 2008',
+    'from 1990 to 2000',
+    'from 2020 to 2025',
+    'from 2010 to 2020',
+    'from 2014 to 2015',
+    'from 2019 to 2024',
+    'from 1926 to 2036',
+    'from 1930 to 1940',
+    'from 1950 to 2000',
+    'from 1970 to 1980',
+    'from 1980 to 1990',
+    'from 2000 to 2010',
+    'from 2015 to 2020',
+    'from 2024 to 2030',
+    'from 2025 to 2036',
+    'from 1998 to 2010',
+    'from 1998 to 2019',
+    'from 2004 to 2019',
+    'from 2001 to 2010',
+    'from 2007 to 2009',
+    # Sentence-embedded 'from...to'.
+    'from 2004 to 2008 we operated under the old framework',
+    'the project ran from 1990 to 2000 without interruption',
+    'from 2019 to 2024 the sector grew at 8% annually',
+    'revenue from 2010 to 2020 increased threefold',
+    'the study covers from 2014 to 2015 and beyond',
+    'the policy was enforced from 2000 to 2010 consistently',
+    'performance from 2020 to 2025 exceeded all projections',
+    'spanning from 1950 to 2000, the era was transformative',
+    # 'From' at sentence start (title case).
+    'From 2004 to 2008 the economy expanded',
+    'From 2010 to 2020 global temperatures rose',
+    # 'FROM' in all caps.
+    'FROM 2019 TO 2024',
+    'FROM 2004 TO 2008',
+])
+def test_year_range_from_to_true_positive(text):
+    """
+    Attack vector: year ranges in the 'from YYYY to YYYY' prose form.
+
+    Why a parser might fail: the 'from...to' form requires matching two separate
+    keywords at a distance. If the parser uses a single regex like
+    ``from\\s+(\\d{4})\\s+to\\s+(\\d{4})``, it will fail when:
+      - The words 'from' and 'to' are separated by additional prose
+      - The expression is at sentence start with capitalisation
+      - The expression uses all-caps (FROM, TO)
+      - Additional words appear between 'from YYYY' and 'to YYYY'
+
+    The sentence-embedded cases test whether the parser correctly extracts the
+    range even when the expression is surrounded by other text. The 'from' and
+    'to' keywords are common English words, so a parser that uses them as
+    anchors must verify that the adjacent tokens are valid 4-digit years.
+
+    What failure reveals: the parser does not recognise the 'from...to' prose
+    form for year ranges, limiting its ability to extract temporal spans from
+    narrative text.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ============================================================================
+# SECTION 3 -- TRUE POSITIVES: BETWEEN...AND FORM
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Simple 'between YYYY and YYYY' expressions.
+    'between 2010 and 2020',
+    'between 1980 and 2000',
+    'between 2014 and 2015',
+    'between 2019 and 2024',
+    'between 1926 and 2036',
+    'between 2000 and 2010',
+    'between 1950 and 2000',
+    'between 1970 and 1990',
+    'between 1990 and 2010',
+    'between 2004 and 2008',
+    'between 2020 and 2030',
+    'between 2024 and 2036',
+    'between 1930 and 1940',
+    'between 1960 and 1970',
+    'between 1980 and 1985',
+    'between 1998 and 2010',
+    'between 2001 and 2011',
+    'between 2007 and 2009',
+    'between 2015 and 2020',
+    'between 2025 and 2035',
+    # Sentence-embedded 'between...and'.
+    'between 2010 and 2020 there was significant growth',
+    'the gap between 1980 and 2000 saw major changes',
+    'between 2014 and 2015 the protocol was revised',
+    'revenues between 2019 and 2024 grew by 40%',
+    'the period between 1950 and 2000 defined the modern era',
+    'activity between 2004 and 2008 was above average',
+    'between 2020 and 2030 we forecast a compound rate of 5%',
+    'the span between 1926 and 2036 covers the full dataset',
+    # 'Between' at sentence start (title case).
+    'Between 2010 and 2020 global GDP doubled',
+    'Between 1970 and 1990 inflation remained high',
+    # All caps.
+    'BETWEEN 2010 AND 2020',
+    'BETWEEN 2004 AND 2008',
+])
+def test_year_range_between_and_true_positive(text):
+    """
+    Attack vector: year ranges in the 'between YYYY and YYYY' prose form.
+
+    Why a parser might fail: the word 'and' is one of the most common words in
+    English, appearing in virtually every sentence. A parser that scans for 'and'
+    as a range connector must verify that it is preceded by 'between YYYY' and
+    followed by 'YYYY'. Without this full structural check, the parser would produce
+    thousands of false positives on sentences that contain 'and' between numbers.
+
+    The sentence-embedded cases (e.g., "the gap between 1980 and 2000 saw major
+    changes") test whether the parser correctly handles the 'between' keyword when
+    it is preceded by a noun phrase and followed by prose. A regex anchored to
+    the start of the string will miss all of these.
+
+    Case variants ('Between', 'BETWEEN') test case sensitivity handling. All-caps
+    versions are common in legal documents, financial tables, and government reports.
+
+    What failure reveals: the parser does not recognise the 'between...and' form,
+    a common and important year-range pattern in analytical and historical writing.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ============================================================================
+# SECTION 4 -- TRUE POSITIVES: SENTENCE EMBEDDED (all three forms)
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Hyphen form embedded.
+    'the period 2014-2015 saw unprecedented growth',
+    'data from the 2019-2020 fiscal year',
+    'the 2010-2020 decade was transformative',
+    'performance during 2000-2010 exceeded targets',
+    'the 1970-1980 era of stagflation affected policy',
+    'records for 1990-2000 are available in the archive',
+    'the 1926-2036 dataset spans the full study period',
+    'see the 2024-2025 projections in appendix B',
+    'the 2004-2008 expansion is well documented',
+    '2020-2030 is the strategic planning horizon',
+    # From...to form embedded.
+    'from 2004 to 2008 we grew at 12% annually',
+    'the company expanded from 1990 to 2000 dramatically',
+    'from 2019 to 2024, three new product lines were launched',
+    'revenues from 2010 to 2020 increased threefold across all segments',
+    'from 1970 to 1980 the industry was regulated differently',
+    'changes from 2000 to 2010 were significant and measurable',
+    # Between...and form embedded.
+    'the period between 2010 and 2020 there was significant growth',
+    'performance between 2004 and 2008 exceeded all benchmarks',
+    'between 2019 and 2024 the regulatory landscape shifted',
+    'the interval between 1980 and 2000 contains the data we need',
+    'between 1950 and 2000 the population doubled',
+    'studies between 2000 and 2010 confirm the trend',
+])
+def test_year_range_sentence_embedded_true_positive(text):
+    """
+    Attack vector: all three year-range forms embedded in natural-language sentences.
+
+    Why a parser might fail: see the detailed rationale in sections 1-3. The
+    additional challenge in sentence-embedded contexts is that each form must be
+    extracted from surrounding prose without being anchored to the string boundaries.
+
+    The 'from 2004 to 2008 we grew' case tests that the parser does not extend
+    the match to include 'we grew' as part of the year range. The 'data from the
+    2019-2020 fiscal year' case tests that 'the' (an article between 'from' and
+    the year range) does not break the hyphen-form pattern.
+
+    What failure reveals: the parser's pattern matching is too narrow for real
+    prose inputs, requiring artificially clean (preposition-adjacent-to-year)
+    structures.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0
+
+
+# ============================================================================
+# SECTION 5 -- FALSE POSITIVES: INVERTED HYPHEN (end before start)
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Year pairs where the second year is smaller than the first.
+    # Semantically invalid as a time range (time cannot run backwards).
+    # A parser that validates year ordering should reject these.
+    '2015-2014',
+    '2020-2000',
+    '2024-2023',
+    '2036-1926',
+    '2030-2020',
+    '2025-2020',
+    '2020-2010',
+    '2010-2000',
+    '2000-1990',
+    '1990-1980',
+    '1980-1970',
+    '1970-1960',
+    '1960-1950',
+    '1950-1940',
+    '1940-1930',
+    '2036-2035',
+    '2035-2020',
+    '2019-2018',
+    '2018-2017',
+    '2017-2016',
+    '2016-2015',
+    '2008-2004',
+    '2004-1998',
+    '2001-1999',
+])
+def test_year_range_inverted_false_positive(text):
+    """
+    Attack vector: hyphen-delimited pairs where the end year is earlier than the
+    start year (inverted temporal order).
+
+    Why a parser might fail (producing a false positive): a regex that matches
+    any ``\\d{4}-\\d{4}`` pattern without validating that the left year is less
+    than the right year will accept inverted pairs. The string '2015-2014' passes
+    the structural test (both are 4-digit numbers in range) but fails the semantic
+    test (time cannot run backwards in a range).
+
+    The exception to this rule is 'circa' use cases where the author writes a
+    year range in reverse to indicate a counting-down context ('by 2014-2000 we
+    had completed X'). This is unusual enough that the parser should default to
+    requiring ascending order and document any exceptions explicitly.
+
+    What failure reveals (false positive produced): the parser does not validate
+    year ordering within hyphen-delimited ranges, accepting semantically invalid
+    inputs and potentially misclassifying other numeric patterns (like phone
+    fragments that happen to have two valid year-range year values) as ranges.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ============================================================================
+# SECTION 6 -- FALSE POSITIVES: MATH EXPRESSIONS
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Arithmetic subtraction expressions where both operands happen to be in the
+    # year range [1926, 2036]. These are NOT year ranges.
+    '2048-1024',
+    '2000-1000',
+    '2036-1926',    # min/max boundary values but as math, not a range
+    '2024-1024',
+    '1980-1024',
+    '2000-1536',
+    '2020-1984',
+    '2024-2000',    # result = 24 (valid subtraction)
+    '2000-1900',    # result = 100
+    '2036-2000',    # result = 36
+    '1990-1960',    # result = 30
+    '2020-1970',    # result = 50
+    '2024-2016',    # result = 8
+    '2030-1030',
+    '2000-1000',
+    # In explicit arithmetic context.
+    'calculate 2048-1024 = 1024',
+    'the sum 2000-1000 equals 1000',
+    '2024 - 2016 = 8',    # with spaces around the hyphen
+    'answer: 2036-1926=110',
+])
+def test_year_range_math_false_positive(text):
+    """
+    Attack vector: arithmetic subtraction expressions where both operands fall
+    within the valid year range, making them structurally identical to year ranges.
+
+    Why a parser might fail (producing a false positive): without semantic
+    context, the string '2024-2016' is structurally identical to a year range
+    and to arithmetic subtraction. The parser cannot distinguish them from
+    structure alone.
+
+    Disambiguation strategies include:
+      1. Requiring surrounding context (preposition before, or 'the ... period'
+         phrasing).
+      2. Validating that the result is a positive, multi-year span (e.g., minimum
+         span of 1 year), which rejects very small differences like '2024-2023'.
+      3. Requiring that neither operand is an unreasonably round power-of-two
+         (1024, 2048) that indicates a mathematical context.
+
+    None of these heuristics are perfect. The test records current behaviour and
+    helps the maintainer decide the appropriate trade-off between recall and
+    precision for the hyphen-form year range.
+
+    What failure reveals (false positive produced): the parser cannot distinguish
+    year-range hyphens from arithmetic minus signs.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ============================================================================
+# SECTION 7 -- FALSE POSITIVES: PHONE FRAGMENTS
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Phone number fragments where the first component is a valid year but
+    # the second component is a 4-digit local number outside the year range.
+    '2014-5678',
+    '2019-9999',
+    '2020-1234',
+    '2024-5555',
+    '2010-9876',
+    '1990-4321',
+    '2000-8765',
+    '2015-3456',
+    '2030-7890',
+    '1970-2468',
+    '1980-1357',
+    '1950-6543',
+    '2036-9876',
+    '1926-2345',
+    '2024-8080',    # year + port number
+    '2020-4040',
+    '2019-6060',
+    '2000-5050',
+    # In context of a phone number.
+    'call us at 2024-5678 for details',
+    'extension 2019-9999',
+    'fax: 2020-1234',
+])
+def test_year_range_phone_fragment_false_positive(text):
+    """
+    Attack vector: phone number fragments where the first 4 digits form a valid
+    year but the second 4 digits (5678, 9999, 1234, etc.) are outside the valid
+    year range [1926, 2036].
+
+    Why a parser might fail (producing a false positive): if the parser only
+    validates the LEFT side of the hyphen as a valid year (checking that the first
+    4-digit group is in [1926, 2036]) but not the RIGHT side, then '2014-5678'
+    will match because 2014 is a valid year. A correctly implemented parser must
+    validate BOTH sides.
+
+    Phone fragments are extremely common in business documents, especially in
+    regions where local phone numbers are formatted as YYYY-XXXX (such as some
+    South American countries and older North American exchange formats).
+
+    What failure reveals (false positive produced): the parser is not validating
+    both year values in the hyphen-form range, only the left side.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ============================================================================
+# SECTION 8 -- FALSE POSITIVES: ISBN FRAGMENTS
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # ISBN-10 and ISBN-13 fragments where a year-range-looking component appears.
+    '978-2014-3',
+    '0-2020-123-4',
+    '978-2019-456-7',
+    '0-2024-001',
+    '978-2010-000',
+    '0-2000-5',
+    '978-1990-1',
+    '0-2036-9',
+    '978-1926-0',
+    # In context.
+    'ISBN: 978-2014-3',
+    'ISBN-13: 978-2019-456-7',
+    'see also: 0-2020-123-4',
+    # ISSN fragments (8 digits, often shown as XXXX-XXXX).
+    '2024-5678',    # ISSN-like format (same as phone test but context)
+    '2019-0001',
+    '2020-9999',
+    '1990-0000',
+    # DOI fragments.
+    '10.2014/example',
+    '10.2020/some-identifier',
+])
+def test_year_range_isbn_fragment_false_positive(text):
+    """
+    Attack vector: ISBN, ISSN, and DOI fragments where a year-like number appears
+    within a longer identifier separated by hyphens.
+
+    Why a parser might fail (producing a false positive): ISBN-13 numbers in the
+    'ISBN 978-YYYY-XXXX' format contain a 4-digit publisher prefix that may happen
+    to be in the valid year range. A parser that does not look at surrounding context
+    (the '978-' prefix indicates an ISBN, not a year range) will incorrectly extract
+    the publisher code as a year.
+
+    DOI identifiers (10.XXXX/...) are another common source of false positives:
+    the XXXX portion is a registrant code that may look like a year.
+
+    ISSN identifiers are formatted as XXXX-XXXX (8 digits, hyphen-separated), and
+    are structurally identical to the YYYY-YYYY year-range format. The difference
+    is purely semantic: the ISSN registrant number '2019' in ISSN 2019-0001 refers
+    to a journal identifier, not the year 2019.
+
+    What failure reveals (false positive produced): the parser is matching
+    structured identifier fragments as year ranges, which would be particularly
+    harmful in bibliographic and library systems.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ============================================================================
+# SECTION 9 -- FALSE POSITIVES: SAME-YEAR BOTH SIDES
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Year ranges where both sides are the same year (zero-duration range).
+    '2024-2024',
+    '2020-2020',
+    '2019-2019',
+    '2010-2010',
+    '2000-2000',
+    '1990-1990',
+    '1970-1970',
+    '1950-1950',
+    '1926-1926',
+    '2036-2036',
+    '2030-2030',
+    '2025-2025',
+    '2015-2015',
+    '2005-2005',
+    '2001-2001',
+    # In 'between...and' form.
+    'between 2010 and 2010',
+    'between 2024 and 2024',
+    'between 2020 and 2020',
+    'between 2000 and 2000',
+    'between 1990 and 1990',
+    # In 'from...to' form.
+    'from 2020 to 2020',
+    'from 2024 to 2024',
+    'from 2010 to 2010',
+    'from 2000 to 2000',
+])
+def test_year_range_same_year_false_positive(text):
+    """
+    Attack vector: year range expressions where the start and end year are
+    identical (zero-duration range).
+
+    Why a parser might fail (producing a false positive): a parser that validates
+    only that both sides are valid years in range, without checking that the end
+    year is STRICTLY GREATER than the start year, will accept '2024-2024' as a
+    valid year range. Whether this is a bug or a feature is a policy decision.
+
+    The argument for rejecting same-year ranges: a range with identical endpoints
+    is semantically equivalent to a single year reference, not a range. Accepting
+    it as a YEAR_RANGE classification creates a dual-classification problem where
+    '2024-2024' would be classified differently from '2024' alone.
+
+    The argument for accepting same-year ranges: in some contexts (e.g., financial
+    reporting: 'the 2024-2024 fiscal year') same-year ranges are conventional and
+    meaningful. The test records current behaviour without committing to a policy.
+
+    What failure reveals (false positive produced): the parser accepts zero-duration
+    ranges, creating potential downstream issues in systems that compute date spans.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) == 0
+
+
+# ============================================================================
+# SECTION 10 -- BOUNDARY: RANGE LIMITS AND EDGE CASES
+# ============================================================================
+
+@pytest.mark.parametrize('text, description', [
+    # Start at minimum, end at maximum -- the widest possible valid range.
+    ('1926-2036', 'full valid range (min to max)'),
+    ('from 1926 to 2036', 'full valid range, from...to form'),
+    ('between 1926 and 2036', 'full valid range, between...and form'),
+
+    # Start below minimum -- should be rejected.
+    ('1925-2030', 'start year below minimum (1925 < 1926)'),
+    ('1924-2036', 'start year well below minimum'),
+    ('1900-2020', 'start year far below minimum'),
+    ('from 1925 to 2030', 'from...to form, start below minimum'),
+    ('between 1925 and 2030', 'between...and form, start below minimum'),
+
+    # End above maximum -- should be rejected.
+    ('2020-2037', 'end year above maximum (2037 > 2036)'),
+    ('1990-2040', 'end year well above maximum'),
+    ('2000-2100', 'end year far above maximum'),
+    ('from 2020 to 2037', 'from...to form, end above maximum'),
+    ('between 2020 and 2037', 'between...and form, end above maximum'),
+
+    # Both outside range.
+    ('1900-1925', 'both years below minimum'),
+    ('2037-2040', 'both years above maximum'),
+
+    # Same-year forms (covered also in section 9 for additional boundary context).
+    ('between 2010 and 2010', 'same year -- zero duration range'),
+    ('from 2020 to 2019', 'from...to form, inverted (end before start)'),
+    ('between 2020 and 2010', 'between...and form, inverted'),
+
+    # One-year adjacent to boundary.
+    ('1926-2036', 'exact boundaries'),
+    ('1927-2035', 'one inside each boundary'),
+    ('1926-2035', 'min boundary, max-1'),
+    ('1927-2036', 'min+1, max boundary'),
+])
+def test_year_range_boundary(text, description):
+    """
+    Attack vector: year range expressions at the exact boundaries of the supported
+    year range [1926, 2036], one step beyond the boundaries in each direction, and
+    semantically invalid forms (inverted, same-year).
+
+    Why a parser might fail: off-by-one errors in the year-range guard are
+    symmetric with the prose-year boundary tests in FILE 2. This section extends
+    that analysis to the three structural forms of year ranges and adds the
+    inversion and zero-duration edge cases.
+
+    The 'from 2020 to 2019' case (inverted 'from...to') is particularly important
+    because it tests whether the parser validates the year ordering in prose form
+    the same way it does in hyphen form. Inconsistent behaviour between the two
+    forms would indicate that the ordering check is implemented separately (and
+    possibly incorrectly) for each pattern.
+
+    This test does not assert a direction because the correct behaviour for some
+    of these edge cases depends on the project's explicit policy (e.g., whether
+    same-year ranges are accepted). The xfail mark at module level captures all
+    outcomes for review in issue #43.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert isinstance(result, dict)
+
+
+# ============================================================================
+# SECTION 11 -- UNICODE: HYPHEN VARIANT ATTACKS
+# ============================================================================
+
+@pytest.mark.parametrize('text, description', [
+    # En-dash (U+2013) replacing hyphen-minus in YYYY-YYYY.
+    # En-dashes are the typographically correct separator for year ranges in
+    # professional typography (e.g., 2014-2015 should be typeset as 2014-2015
+    # using an en-dash). Many documents from publishing, legal, and academic
+    # contexts will use en-dashes.
+    ('2014\u20132015', 'en-dash year range (U+2013): 2014\u20132015'),
+    ('2019\u20132024', 'en-dash year range (U+2013): 2019\u20132024'),
+    ('2010\u20132020', 'en-dash year range (U+2013): 2010\u20132020'),
+    ('1926\u20132036', 'en-dash year range (U+2013): 1926\u20132036'),
+    ('2000\u20132010', 'en-dash year range (U+2013): 2000\u20132010'),
+
+    # Em-dash (U+2014) replacing hyphen-minus in YYYY-YYYY.
+    # Em-dashes are sometimes used in informal or typewriter-era typography.
+    ('2014\u20142015', 'em-dash year range (U+2014): 2014\u20142015'),
+    ('2019\u20142024', 'em-dash year range (U+2014): 2019\u20142024'),
+    ('2010\u20142020', 'em-dash year range (U+2014): 2010\u20142020'),
+    ('1926\u20142036', 'em-dash year range (U+2014): 1926\u20142036'),
+
+    # Minus sign (U+2212) replacing hyphen-minus.
+    # The Unicode minus sign is used in mathematical typesetting and appears in
+    # copy-pasted text from LaTeX documents or equation editors.
+    ('2014\u22122015', 'minus sign year range (U+2212): 2014\u22122015'),
+    ('2019\u22122024', 'minus sign year range (U+2212): 2019\u22122024'),
+    ('2010\u22122020', 'minus sign year range (U+2212): 2010\u22122020'),
+    ('1926\u22122036', 'minus sign year range (U+2212): 1926\u22122036'),
+
+    # Fullwidth hyphen-minus (U+FF0D) replacing ASCII hyphen-minus (U+002D).
+    # Fullwidth characters are used in CJK (Chinese, Japanese, Korean) text
+    # environments and appear in content that was originally formatted for
+    # East Asian display systems.
+    ('2014\uFF0D2015', 'fullwidth hyphen-minus (U+FF0D): 2014\uFF0D2015'),
+    ('2019\uFF0D2024', 'fullwidth hyphen-minus (U+FF0D): 2019\uFF0D2024'),
+    ('2010\uFF0D2020', 'fullwidth hyphen-minus (U+FF0D): 2010\uFF0D2020'),
+    ('1926\uFF0D2036', 'fullwidth hyphen-minus (U+FF0D): 1926\uFF0D2036'),
+
+    # Combining minus (U+2212) in sentence context.
+    ('the period 2014\u20132015 was significant', 'en-dash in sentence context'),
+    ('from 2004\u20132008 the trend was positive', "en-dash after 'from'"),
+    ('the 2019\u20142024 era is well studied', 'em-dash in sentence context'),
+
+    # Fullwidth digits around standard hyphen (hybrid attack).
+    ('\uFF12\uFF10\uFF12\uFF14-2015', 'fullwidth start year + ASCII hyphen'),
+    ('2014-\uFF12\uFF10\uFF11\uFF15', 'ASCII hyphen + fullwidth end year'),
+])
+def test_year_range_unicode_hyphen(text, description):
+    """
+    Attack vector: year range expressions using Unicode hyphen variants in place
+    of the ASCII hyphen-minus (U+002D).
+
+    Why a parser might be affected: the typographically correct separator for a
+    year range is an en-dash (U+2013), not a hyphen-minus (U+002D). A parser
+    whose regex uses the literal ASCII hyphen '-' will not match en-dash or
+    em-dash variants, causing it to miss year ranges in professionally typeset
+    documents, legal texts, and academic papers.
+
+    The four Unicode hyphen variants tested here cover the most common cases:
+      - U+2013 (en-dash): the correct typographic separator for ranges
+      - U+2014 (em-dash): the typewriter alternative and informal separator
+      - U+2212 (minus sign): used in mathematical typesetting (LaTeX, equation editors)
+      - U+FF0D (fullwidth hyphen-minus): used in CJK text environments
+
+    The correct handling policy is a design decision:
+      Option A (strict ASCII): reject all Unicode hyphens -- pure ASCII matching
+      Option B (Unicode-aware): normalise all hyphen variants to U+002D before
+                                matching, accepting en-dash and em-dash ranges
+      Option C (selective): only accept en-dash (U+2013) as an additional
+                            separator alongside ASCII hyphen
+
+    This test records current behaviour without asserting direction, enabling the
+    maintainer to make an explicit policy decision in issue #43.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert isinstance(result, dict)
+
+
+# ============================================================================
+# SECTION 12 -- ADDITIONAL TRUE POSITIVES (reaching 250+ total cases)
+# ============================================================================
+
+@pytest.mark.parametrize('text', [
+    # Additional hyphen-form pairs not in section 1.
+    '1927-1928',
+    '1929-1930',
+    '1933-1934',
+    '1936-1937',
+    '1938-1939',
+    '1942-1943',
+    '1945-1946',
+    '1948-1949',
+    '1952-1953',
+    '1955-1956',
+    '1958-1959',
+    '1962-1963',
+    '1965-1966',
+    '1968-1969',
+    '1972-1973',
+    '1975-1976',
+    '1978-1979',
+    '1982-1983',
+    '1985-1986',
+    '1988-1989',
+    '1992-1993',
+    '1995-1996',
+    '1998-1999',
+    '2002-2003',
+    '2006-2007',
+    '2008-2009',
+    '2011-2012',
+    '2012-2013',
+    '2013-2014',
+    '2016-2017',
+    '2017-2018',
+    '2018-2019',
+    '2021-2022',
+    '2022-2023',
+    # Additional from...to forms.
+    'from 1927 to 1929',
+    'from 1945 to 1950',
+    'from 1955 to 1965',
+    'from 1975 to 1985',
+    'from 1985 to 1995',
+    'from 1995 to 2005',
+    'from 2005 to 2015',
+    'from 2016 to 2018',
+    'from 2017 to 2019',
+    'from 2021 to 2023',
+    'from 2022 to 2024',
+    'from 2023 to 2025',
+    'from 2026 to 2028',
+    'from 2028 to 2030',
+    'from 2032 to 2034',
+    # Additional between...and forms.
+    'between 1927 and 1929',
+    'between 1945 and 1950',
+    'between 1955 and 1965',
+    'between 1975 and 1985',
+    'between 1985 and 1995',
+    'between 1995 and 2005',
+    'between 2005 and 2015',
+    'between 2016 and 2018',
+    'between 2021 and 2023',
+    'between 2022 and 2024',
+    'between 2023 and 2025',
+    'between 2026 and 2028',
+    'between 2028 and 2030',
+    'between 2032 and 2034',
+    'between 2034 and 2036',
+    # Sentence-embedded additional forms.
+    'growth from 1945 to 1950 exceeded expectations',
+    'between 1955 and 1965 the industry restructured',
+    'the 1975-1985 decade saw major regulatory changes',
+    'from 1985 to 1995 was an era of rapid expansion',
+    'the 1995-2000 dot-com boom is well documented',
+    'from 2001 to 2010 the recovery was uneven',
+    'between 2012 and 2016 the market stabilised',
+    'the 2016-2020 period coincided with policy shifts',
+    'from 2021 to 2024 the sector adapted to new norms',
+    'between 2024 and 2028 the projections are optimistic',
+    'the 2028-2032 window is critical for the transition',
+    'from 2032 to 2036 we expect full deployment',
+])
+def test_year_range_additional_true_positive(text):
+    """
+    Attack vector: additional year-range pairs in all three structural forms,
+    spanning dense year-over-year adjacent pairs and intermediate multi-year spans.
+
+    Why a parser might fail: dense year-over-year pairs (1927-1928, 1929-1930,
+    etc.) test whether the parser correctly handles all consecutive years in the
+    valid range [1926, 2036], not just the 'interesting' ones (decade starts,
+    well-known historical years). A parser tuned on a sparse training set may miss
+    years that were never in the training vocabulary.
+
+    The sentence-embedded additional cases extend the context-handling test to
+    a wider variety of surrounding prose patterns, ensuring that neither the
+    preceding noun phrase nor the trailing verb phrase disrupts pattern matching.
+
+    What failure reveals: each failing case identifies a specific year-pair or
+    sentence context where the parser's year-range extraction fails, enabling
+    targeted coverage improvement.
+
+    Related GitHub Issue: #43 https://github.com/craigtrim/fast-parse-time/issues/43
+    """
+    result = extract_explicit_dates(text)
+    assert len(result) > 0


### PR DESCRIPTION
## Summary

- Adds `tests/red_team/` with 16 files and 3,500+ parametrized test cases covering all pattern types
- Tests are organized into four attack categories: true positive attacks, false positive defense, boundary/edge cases, and unicode/homoglyph attacks
- All tests run as `xfail` (Phase 1); unexpected passes (`xpass`) are Phase 2 promotion candidates

## Test plan

- [ ] `python -m pytest tests/red_team/ -q` → all tests collected, no errors
- [ ] Suite reports only `xfail` / `xpassed` — no hard failures
- [ ] Pre-commit hooks pass (linters clean)

Closes #43